### PR TITLE
Add minimal stack-chan-ai Realtime voice adapter

### DIFF
--- a/.changeset/stackchan-ai-realtime.md
+++ b/.changeset/stackchan-ai-realtime.md
@@ -1,0 +1,5 @@
+---
+"@stack-chan/firmware": minor
+---
+
+Add a server-backed Realtime voice adapter for stack-chan-ai on M5StackChan CoreS3.

--- a/.changeset/stackchan-ai-realtime.md
+++ b/.changeset/stackchan-ai-realtime.md
@@ -3,3 +3,4 @@
 ---
 
 Add a server-backed Realtime voice adapter for stack-chan-ai on M5StackChan CoreS3.
+Cleartext authenticated endpoints are restricted to trusted local networks, and credentials must be sent in headers rather than endpoint URLs.

--- a/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
+++ b/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
@@ -24,7 +24,13 @@ const tools: Record<string, ChatTool> = {
 
 const states: ChatStateValue[] = []
 const service = new ChatService({
-  config: { type: 'openAIRealtime', modelID: 'gpt-realtime-mini', apiKey: 'test-api-key' },
+  config: {
+    type: 'openAIRealtime',
+    specifier: 'stackchanServerOpenAIRealtime',
+    endpoint: 'ws://192.168.7.140:8787/device/v1/realtime',
+    modelID: 'stackchan-ai',
+    apiKey: 'test-api-key',
+  },
   tools,
   chatAudioIOCtor: ChatAudioIO as unknown as new (chatOptions: Record<string, unknown>) => ChatAudioIOBase,
   callbacks: {
@@ -33,7 +39,12 @@ const service = new ChatService({
 })
 
 const ChatAudioIOAny = ChatAudioIO as unknown as {
-  lastOptions?: { specifier?: string; apiKey?: string; functions?: { name: string }[] }
+  lastOptions?: {
+    specifier?: string
+    providerID?: string
+    apiKey?: string
+    functions?: { name: string }[]
+  }
   instances?: {
     emitState: (state: number) => void
     emitInputTranscript: (text: string, more?: boolean) => void
@@ -51,7 +62,16 @@ if (!lastOptions) {
   throw new Error('ChatAudioIO options should be captured')
 }
 const functions = lastOptions.functions ?? []
-equal(lastOptions.specifier, 'openAIRealtime', 'chat type should map to ChatAudioIO specifier')
+equal(
+  lastOptions.specifier,
+  'stackchanServerOpenAIRealtime',
+  'an explicit worker specifier should override the chat type',
+)
+equal(
+  lastOptions.providerID,
+  'ws://192.168.7.140:8787/device/v1/realtime',
+  'endpoint should be forwarded through the provider configuration slot',
+)
 equal(lastOptions.apiKey, 'test-api-key', 'api key should be forwarded to ChatAudioIO')
 equal(functions.length, 1, 'functions length')
 equal(functions[0] ? functions[0].name : undefined, 'sample', 'function name')

--- a/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
+++ b/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
@@ -132,5 +132,18 @@ service.start()
 equal(service.transcript.input, '', 'start should clear input transcript for the next session')
 equal(service.transcript.output, '', 'start should clear output transcript for the next session')
 
+const defaultService = new ChatService({
+  config: {
+    type: 'openAIRealtime',
+    providerID: 'openai',
+  },
+  chatAudioIOCtor: ChatAudioIO as unknown as new (chatOptions: Record<string, unknown>) => ChatAudioIOBase,
+})
+const defaultOptions = ChatAudioIOAny.lastOptions
+assert(defaultOptions, 'default ChatAudioIO options should be captured')
+equal(defaultOptions?.specifier, 'openAIRealtime', 'a chat type should remain the default worker specifier')
+equal(defaultOptions?.providerID, 'openai', 'a provider ID should remain unchanged without an endpoint override')
+defaultService.close()
+
 trace('ok\n')
 Timer.set(() => {}, 1000)

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/audio-codecs.js
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/audio-codecs.js
@@ -1,5 +1,8 @@
 export const Encode = {
   toAlaw(source, target) {
-    target.set(source.subarray(0, target.length))
+    const samples = source.byteLength >> 1
+    for (let index = 0; index < samples; index += 1) {
+      target[index] = source[index * 2 + 1] ^ 0x55
+    }
   },
 }

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/audio-codecs.js
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/audio-codecs.js
@@ -1,0 +1,5 @@
+export const Encode = {
+  toAlaw(source, target) {
+    target.set(source.subarray(0, target.length))
+  },
+}

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/manifest.test.json
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/manifest.test.json
@@ -1,0 +1,21 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../chat-audioio/server.manifest.json",
+    "../../../testing/manifest.json"
+  ],
+  "modules": {
+    "ChatAudioIO/Codecs": "./audio-codecs",
+    "main": "./server-realtime-model.test",
+    "stackchanServerChatWebSocketWorker": "./server-chat-websocket-worker",
+    "stackchanServerOpenAIRealtimeModel": "../../chat-audioio/server-openai-realtime-model"
+  },
+  "typescript": {
+    "tsconfig": {
+      "compilerOptions": {
+        "noImplicitAny": false
+      }
+    }
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/server-chat-websocket-worker.js
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/server-chat-websocket-worker.js
@@ -1,0 +1,37 @@
+export const sentJSON = []
+export const postedMessages = []
+
+export default class ServerChatWebSocketWorker {
+  constructor(options) {
+    this.options = options
+  }
+
+  connect(message) {
+    this.inputBuffer = message.inputBuffer
+    this.outputBuffer = message.outputBuffer
+  }
+
+  close() {
+    this.closed = true
+  }
+
+  post(id, param) {
+    postedMessages.push({ id, ...param })
+  }
+
+  postMessage(message) {
+    postedMessages.push(message)
+  }
+
+  sendAudio(message) {
+    this.lastAudio = message
+  }
+
+  sendAudioBuffer(buffer) {
+    this.lastAudioBuffer = buffer
+  }
+
+  sendJSON(message) {
+    sentJSON.push(message)
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/server-chat-websocket-worker.js
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/server-chat-websocket-worker.js
@@ -4,9 +4,11 @@ export const postedMessages = []
 export default class ServerChatWebSocketWorker {
   constructor(options) {
     this.options = options
+    this.connectCount = 0
   }
 
   connect(message) {
+    this.connectCount += 1
     this.inputBuffer = message.inputBuffer
     this.outputBuffer = message.outputBuffer
   }
@@ -24,7 +26,8 @@ export default class ServerChatWebSocketWorker {
   }
 
   sendAudio(message) {
-    this.lastAudio = message
+    this.lastAudio = { ...message }
+    this.sendAudioBuffer(new Uint8Array(this.inputBuffer, message.offset, message.size).slice())
   }
 
   sendAudioBuffer(buffer) {

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/server-realtime-model.test.ts
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/server-realtime-model.test.ts
@@ -1,21 +1,63 @@
-import { sentJSON } from 'stackchanServerChatWebSocketWorker'
+import { postedMessages, sentJSON } from 'stackchanServerChatWebSocketWorker'
 import ServerOpenAIRealtimeModel, { parseWebSocketEndpoint } from 'stackchanServerOpenAIRealtimeModel'
 import { equal } from 'testing/assert'
 import Timer from 'timer'
 
 trace('=== server-realtime-model test ===\n')
 
-const localEndpoint = parseWebSocketEndpoint(
-  'ws://192.168.7.140:8787/device/v1/realtime?conversation_id=test&token=device-token',
-)
+const localEndpoint = parseWebSocketEndpoint('ws://192.168.7.140:8787/device/v1/realtime?conversation_id=test')
 equal(localEndpoint.secure, false, 'a LAN websocket endpoint should use the cleartext transport')
 equal(localEndpoint.host, '192.168.7.140', 'endpoint host should be parsed')
 equal(localEndpoint.port, 8787, 'endpoint port should be parsed')
 equal(
   localEndpoint.path,
-  '/device/v1/realtime?conversation_id=test&token=device-token',
-  'endpoint path should retain authentication and conversation query parameters',
+  '/device/v1/realtime?conversation_id=test',
+  'endpoint path should retain conversation query parameters',
 )
+
+const connection = {
+  barrier: new Int32Array(new SharedArrayBuffer(4 * Int32Array.BYTES_PER_ELEMENT)),
+  inputBuffer: new SharedArrayBuffer(2048),
+  outputBuffer: new SharedArrayBuffer(2048),
+}
+const reconfiguredModel = new ServerOpenAIRealtimeModel({ inputSampleRate: 8000 })
+reconfiguredModel.configure({ providerID: 'https://relay.example.test/device/v1/realtime' })
+reconfiguredModel.connect(connection)
+equal(postedMessages.length, 1, 'a non-WebSocket endpoint should fail before connecting')
+equal(
+  postedMessages[0]?.string,
+  'ChatService endpoint must use ws:// or wss://',
+  'the endpoint failure should be explicit',
+)
+postedMessages.length = 0
+reconfiguredModel.configure({
+  providerID: 'ws://relay.example.test/device/v1/realtime',
+  apiKey: 'test-token',
+})
+reconfiguredModel.connect(connection)
+equal(postedMessages.length, 1, 'Bearer authentication should be rejected on public ws endpoints')
+equal(
+  postedMessages[0]?.string,
+  'ChatService Bearer authentication over ws:// is restricted to trusted local networks',
+  'the public cleartext authentication failure should be explicit',
+)
+postedMessages.length = 0
+reconfiguredModel.configure({
+  providerID: 'ws://192.168.7.140:8787/device/v1/realtime?token=device-token',
+})
+reconfiguredModel.connect(connection)
+equal(postedMessages.length, 1, 'credentials should be rejected in a cleartext endpoint URL')
+equal(postedMessages[0]?.string, 'ChatService credentials must not be embedded in a ws:// endpoint')
+postedMessages.length = 0
+reconfiguredModel.configure({
+  providerID: 'ws://192.168.7.140:8787/device/v1/realtime?conversation_id=test',
+  apiKey: 'device-token',
+})
+reconfiguredModel.connect(connection)
+equal(reconfiguredModel.connectCount, 1, 'a valid trusted-LAN configuration should replace earlier failures')
+equal(postedMessages.length, 0, 'a valid reconfiguration should not retain an earlier failure')
+equal(reconfiguredModel.headers[0]?.[0], 'Authorization', 'trusted-LAN authentication should use a header')
+equal(reconfiguredModel.headers[0]?.[1], 'Bearer device-token', 'the device token should stay out of the endpoint URL')
 
 const model = new ServerOpenAIRealtimeModel({ inputSampleRate: 8000 })
 const tool = {
@@ -49,15 +91,14 @@ equal(
 )
 equal(sessionUpdate?.session?.tool_choice, 'auto', 'session update should enable automatic tool selection')
 
-const barrier = new Int32Array(new SharedArrayBuffer(4 * Int32Array.BYTES_PER_ELEMENT))
-const inputBuffer = new SharedArrayBuffer(2048)
-model.connect({
-  barrier,
-  inputBuffer,
-  outputBuffer: new SharedArrayBuffer(2048),
-})
-model.sendAudio({ offset: 0, size: 1024, sequence: 7 })
-equal(model.lastAudio?.size, 512, 'PCM16 input should be encoded to one byte per PCMA sample')
+model.connect(connection)
+const input = new Uint8Array(connection.inputBuffer)
+input.set([0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80])
+model.sendAudio({ offset: 0, size: 8, sequence: 7 })
+equal(model.lastAudio?.size, 4, 'PCM16 input should be encoded to one byte per PCMA sample')
+equal(model.lastAudioBuffer?.byteLength, 4, 'only encoded PCMA bytes should reach the transport')
+equal(model.lastAudioBuffer?.[0], 0x20 ^ 0x55, 'the first encoded sample should reach the transport')
+equal(model.lastAudioBuffer?.[3], 0x80 ^ 0x55, 'the final encoded sample should reach the transport')
 
 sentJSON.length = 0
 model.sendFunctionResult({ call: 'call-1', result: { ok: true } })

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/server-realtime-model.test.ts
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/server-realtime-model.test.ts
@@ -1,0 +1,72 @@
+import { sentJSON } from 'stackchanServerChatWebSocketWorker'
+import ServerOpenAIRealtimeModel, { parseWebSocketEndpoint } from 'stackchanServerOpenAIRealtimeModel'
+import { equal } from 'testing/assert'
+import Timer from 'timer'
+
+trace('=== server-realtime-model test ===\n')
+
+const localEndpoint = parseWebSocketEndpoint(
+  'ws://192.168.7.140:8787/device/v1/realtime?conversation_id=test&token=device-token',
+)
+equal(localEndpoint.secure, false, 'a LAN websocket endpoint should use the cleartext transport')
+equal(localEndpoint.host, '192.168.7.140', 'endpoint host should be parsed')
+equal(localEndpoint.port, 8787, 'endpoint port should be parsed')
+equal(
+  localEndpoint.path,
+  '/device/v1/realtime?conversation_id=test&token=device-token',
+  'endpoint path should retain authentication and conversation query parameters',
+)
+
+const model = new ServerOpenAIRealtimeModel({ inputSampleRate: 8000 })
+const tool = {
+  name: 'setEmotion',
+  description: 'set the face emotion',
+  parameters: {
+    type: 'object',
+    properties: { emotion: { type: 'string' } },
+    required: ['emotion'],
+  },
+}
+model.configure({
+  providerID: 'wss://relay.example.test/device/v1/realtime',
+  apiKey: 'test-token',
+  voiceID: 'cedar',
+  instructions: 'Be cheerful.',
+  functions: [tool],
+})
+model['session.created']()
+
+const sessionUpdate = sentJSON[0]
+equal(sessionUpdate?.type, 'session.update', 'session creation should send a session update')
+equal(sessionUpdate?.session?.instructions, 'Be cheerful.', 'session update should forward instructions')
+equal(sessionUpdate?.session?.tools?.length, 1, 'session update should forward tools')
+equal(sessionUpdate?.session?.tools?.[0]?.type, 'function', 'session tools should use the function type')
+equal(sessionUpdate?.session?.tools?.[0]?.name, 'setEmotion', 'session update should preserve the tool name')
+equal(
+  sessionUpdate?.session?.tools?.[0]?.parameters?.additionalProperties,
+  false,
+  'session tools should reject undeclared parameters',
+)
+equal(sessionUpdate?.session?.tool_choice, 'auto', 'session update should enable automatic tool selection')
+
+const barrier = new Int32Array(new SharedArrayBuffer(4 * Int32Array.BYTES_PER_ELEMENT))
+const inputBuffer = new SharedArrayBuffer(2048)
+model.connect({
+  barrier,
+  inputBuffer,
+  outputBuffer: new SharedArrayBuffer(2048),
+})
+model.sendAudio({ offset: 0, size: 1024, sequence: 7 })
+equal(model.lastAudio?.size, 512, 'PCM16 input should be encoded to one byte per PCMA sample')
+
+sentJSON.length = 0
+model.sendFunctionResult({ call: 'call-1', result: { ok: true } })
+equal(sentJSON.length, 2, 'a function result should be followed by a response request')
+equal(sentJSON[0]?.type, 'conversation.item.create', 'the function output should be sent first')
+equal(sentJSON[0]?.item?.type, 'function_call_output', 'the first item should contain the function output')
+equal(sentJSON[0]?.item?.call_id, 'call-1', 'the function output should preserve the call id')
+equal(sentJSON[0]?.item?.output, '{"ok":true}', 'the function output should serialize the result')
+equal(sentJSON[1]?.type, 'response.create', 'the function output should resume the assistant response')
+
+trace('ok\n')
+Timer.set(() => {}, 1000)

--- a/firmware/host/modules/conversation/__tests__/server-websocket-worker/chat-worker.js
+++ b/firmware/host/modules/conversation/__tests__/server-websocket-worker/chat-worker.js
@@ -1,0 +1,16 @@
+export const postedMessages = []
+
+export default class ChatWorker {
+  constructor(options) {
+    this.options = options
+  }
+
+  connect(message) {
+    this.inputBuffer = message.inputBuffer
+    this.outputBuffer = message.outputBuffer
+  }
+
+  postMessage(message) {
+    postedMessages.push(message)
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/server-websocket-worker/json-base64-parser.js
+++ b/firmware/host/modules/conversation/__tests__/server-websocket-worker/json-base64-parser.js
@@ -1,0 +1,8 @@
+export default class JSONBase64Parser {
+  constructor() {
+    this.result = undefined
+  }
+
+  read() {}
+  reset() {}
+}

--- a/firmware/host/modules/conversation/__tests__/server-websocket-worker/manifest.test.json
+++ b/firmware/host/modules/conversation/__tests__/server-websocket-worker/manifest.test.json
@@ -2,14 +2,15 @@
   "include": [
     "$(MODDABLE)/examples/manifest_base.json",
     "$(MODDABLE)/examples/manifest_typings.json",
+    "$(MODDABLE)/modules/data/text/encoder/manifest.json",
     "../../manifest.json",
     "../../../testing/manifest.json"
   ],
   "modules": {
-    "ChatAudioIO/Codecs": "./audio-codecs",
-    "main": "./server-realtime-model.test",
-    "stackchanServerChatWebSocketWorker": "./server-chat-websocket-worker",
-    "stackchanServerOpenAIRealtimeModel": "../../chat-audioio/server-openai-realtime-model"
+    "ChatWorker": "./chat-worker",
+    "JSONBase64Parser": "./json-base64-parser",
+    "main": "./server-websocket-worker.test",
+    "stackchanServerChatWebSocketWorker": "../../chat-audioio/server-chat-websocket-worker"
   },
   "typescript": {
     "tsconfig": {

--- a/firmware/host/modules/conversation/__tests__/server-websocket-worker/server-websocket-worker.test.js
+++ b/firmware/host/modules/conversation/__tests__/server-websocket-worker/server-websocket-worker.test.js
@@ -1,0 +1,109 @@
+import ServerChatWebSocketWorker from 'stackchanServerChatWebSocketWorker'
+import { equal } from 'testing/assert'
+import Timer from 'timer'
+
+trace('=== server-websocket-worker test ===\n')
+
+const sockets = []
+
+class FakeWebSocket {
+  static close = 8
+  static ping = 9
+  static pong = 10
+
+  constructor(options) {
+    this.options = options
+    this.writes = []
+    this.readable = new ArrayBuffer(0)
+    sockets.push(this)
+  }
+
+  close() {}
+
+  read() {
+    return this.readable
+  }
+
+  write(data, options) {
+    this.writes.push({ data, options })
+    return 0
+  }
+
+  notifyReadable(data) {
+    this.readable = data
+    this.options.onReadable(data.byteLength, { more: false })
+  }
+
+  notifyWritable(count) {
+    this.options.onWritable(count)
+  }
+}
+
+class SecureWebSocket extends FakeWebSocket {
+  static close = 88
+}
+
+class TestWorker extends ServerChatWebSocketWorker {
+  eventHandlers = Object.freeze({ 'session.created': true })
+  openCount = 0
+  readCount = 0
+  sessionCreatedCount = 0
+
+  onOpen() {
+    this.openCount += 1
+  }
+
+  read() {
+    this.readCount += 1
+  }
+
+  'session.created'() {
+    this.sessionCreatedCount += 1
+  }
+}
+
+globalThis.device = {
+  network: {
+    ws: { io: FakeWebSocket },
+    wss: { io: SecureWebSocket },
+  },
+}
+
+const connection = {
+  barrier: new Int32Array(new SharedArrayBuffer(4 * Int32Array.BYTES_PER_ELEMENT)),
+  inputBuffer: new SharedArrayBuffer(2048),
+  outputBuffer: new SharedArrayBuffer(2048),
+}
+
+const queuedWorker = new TestWorker({ outputSampleRate: 24000 })
+queuedWorker.connect(connection)
+queuedWorker.sendJSON({ type: 'queued.before.open' })
+const queuedSocket = sockets[0]
+equal(queuedSocket?.writes.length, 0, 'a write should queue until the socket reports capacity')
+queuedSocket?.notifyWritable(256)
+equal(queuedWorker.openCount, 1, 'the first writable callback should open the worker once')
+equal(queuedSocket?.writes.length, 1, 'the first writable callback should flush queued data')
+
+const earlyReadWorker = new TestWorker({ outputSampleRate: 24000 })
+earlyReadWorker.connect(connection)
+const earlyReadSocket = sockets[1]
+earlyReadSocket?.notifyReadable(ArrayBuffer.fromString('{"type":"session.created"}'))
+equal(earlyReadWorker.openCount, 1, 'an early readable callback should open the worker')
+equal(earlyReadWorker.readCount, 1, 'data received before the first writable callback should be processed')
+earlyReadSocket?.notifyWritable(256)
+equal(earlyReadWorker.openCount, 1, 'a later writable callback should not reopen the worker')
+
+earlyReadWorker.onJSON({ type: 'disconnect' })
+equal(earlyReadSocket?.writes.length, 0, 'an undeclared remote event must not invoke a transport method')
+earlyReadWorker.onJSON({ type: 'session.created' })
+equal(earlyReadWorker.sessionCreatedCount, 1, 'an explicitly allowed event should invoke its handler')
+
+earlyReadWorker.disconnect()
+equal(
+  earlyReadSocket?.writes[0]?.options.opcode,
+  SecureWebSocket.close,
+  'disconnect should use the close opcode from the selected secure socket class',
+)
+
+trace('ok\n')
+Timer.set(() => {}, 1000)

--- a/firmware/host/modules/conversation/chat-audioio/server-chat-websocket-worker.js
+++ b/firmware/host/modules/conversation/chat-audioio/server-chat-websocket-worker.js
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 Shinya Ishikawa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import ChatWorker from 'ChatWorker'
+import JSONBase64Parser from 'JSONBase64Parser'
+import TextEncoder from 'text/encoder'
+
+const text = Object.freeze({ binary: false })
+const MAX_QUEUED_BYTES = 64 * 1024
+
+export default class ServerChatWebSocketWorker extends ChatWorker {
+  #buffers = []
+  #queuedBytes = 0
+  #state = 0
+  #writable = 0
+  #encoder = new TextEncoder()
+
+  constructor(options) {
+    super(options)
+    this.ws = null
+    this.secure = true
+    this.host = ''
+    this.path = '/'
+    this.port = 443
+    this.headers = []
+    this.outputMinimum = (options.outputSampleRate ?? 24000) >> 1
+    this.silence = new ArrayBuffer(this.outputMinimum)
+  }
+
+  close() {
+    const ws = this.ws
+    this.ws = null
+    this.#buffers = []
+    this.#queuedBytes = 0
+    this.#state = 0
+    this.#writable = 0
+    try {
+      ws?.close()
+    } catch {
+      // The transport may already be closed.
+    }
+  }
+
+  connect(message) {
+    super.connect(message)
+    this.parser = new JSONBase64Parser(this, this.outputBuffer, 2, this.outputMinimum)
+    this.parser.barrier = message.barrier
+    const network = this.secure ? device.network.wss : device.network.ws
+    const WebSocketClient = network.io ?? device.network.ws.io
+    this.ws = new WebSocketClient({
+      ...network,
+      host: this.host,
+      path: this.path,
+      port: this.port,
+      headers: this.headers,
+      onClose: () => {},
+      onControl: (opcode, data) => {
+        switch (opcode) {
+          case WebSocketClient.close: {
+            const bytes = new Uint8Array(data)
+            const code = bytes.length >= 2 ? (bytes[0] << 8) | bytes[1] : 1006
+            const reason = bytes.length > 2 ? String.fromArrayBuffer(bytes.buffer.slice(2)) : 'connection closed'
+            if (code !== 1000) this.postMessage({ id: 'failed', string: reason })
+            else this.postMessage({ id: 'disconnected' })
+            this.close()
+            break
+          }
+          case WebSocketClient.ping:
+          case WebSocketClient.pong:
+            break
+        }
+      },
+      onError: () => {
+        this.postMessage({ id: 'failed', string: 'network error' })
+        this.close()
+      },
+      onReadable: (count, options) => {
+        const buffer = this.ws.read(count)
+        if (this.#state === 1) this.read(buffer, options)
+      },
+      onWritable: (count) => {
+        if (!count) return
+        this.#writable = count
+        if (this.#state === 0) {
+          this.onOpen()
+          this.#state = 1
+          return
+        }
+        this.flushWrites()
+      },
+    })
+  }
+
+  disconnect() {
+    if (!this.ws) return
+    const WebSocketClient = device.network.ws.io
+    const code = 1000
+    this.write(Uint8Array.of(code >> 8, code & 0xff), {
+      opcode: WebSocketClient.close,
+    })
+    this.#state = 2
+  }
+
+  isBase64() {
+    return false
+  }
+
+  onBase64(offset, size) {
+    this.postMessage({ id: 'receiveAudio', offset, size })
+  }
+
+  onJSON(json) {
+    const type = json.type
+    if (type in this) this[type](json)
+  }
+
+  onOpen() {}
+
+  read(data, options) {
+    this.parser.read(data)
+    if (options.more) return
+    this.onJSON(this.parser.result)
+    this.parser.reset()
+  }
+
+  sendAudio(message) {
+    const samples = new Uint8Array(this.inputBuffer, message.offset, message.size)
+    this.sendAudioBuffer(samples)
+  }
+
+  sendAudioBuffer(samples) {
+    const string = samples.toBase64()
+    const data = new Uint8Array(this.audioPrefix.length + string.length + this.audioSuffix.length)
+    data.set(this.audioPrefix)
+    this.#encoder.encodeInto(string, data.subarray(this.audioPrefix.length))
+    data.set(this.audioSuffix, this.audioPrefix.length + string.length)
+    this.write(data, text)
+  }
+
+  sendJSON(json) {
+    this.write(ArrayBuffer.fromString(JSON.stringify(json)), text)
+  }
+
+  write(data, options) {
+    if (!this.ws) return
+    if (this.#buffers.length) {
+      this.enqueue(data, options)
+      return
+    }
+    const writable = this.#writable
+    if (data.byteLength <= writable) {
+      this.#writable = this.ws.write(data, options)
+      return
+    }
+    if (writable > 0) {
+      this.#writable = this.ws.write(data.slice(0, writable), {
+        ...options,
+        more: true,
+      })
+      this.enqueue(data.slice(writable), options)
+      return
+    }
+    this.enqueue(data, options)
+  }
+
+  enqueue(data, options) {
+    if (this.#queuedBytes + data.byteLength > MAX_QUEUED_BYTES) {
+      this.postMessage({ id: 'failed', string: 'websocket backpressure' })
+      this.close()
+      return
+    }
+    this.#buffers.push({ data, options })
+    this.#queuedBytes += data.byteLength
+  }
+
+  flushWrites() {
+    while (this.#buffers.length && this.ws) {
+      const buffer = this.#buffers[0]
+      const data = buffer.data
+      const writable = this.#writable
+      if (data.byteLength <= writable) {
+        this.#writable = this.ws.write(data, buffer.options)
+        this.#queuedBytes -= data.byteLength
+        this.#buffers.shift()
+        continue
+      }
+      if (writable > 0) {
+        this.#writable = this.ws.write(data.slice(0, writable), {
+          ...buffer.options,
+          more: true,
+        })
+        buffer.data = data.slice(writable)
+        this.#queuedBytes -= writable
+      }
+      break
+    }
+  }
+}

--- a/firmware/host/modules/conversation/chat-audioio/server-chat-websocket-worker.js
+++ b/firmware/host/modules/conversation/chat-audioio/server-chat-websocket-worker.js
@@ -15,6 +15,7 @@ const MAX_QUEUED_BYTES = 64 * 1024
 export default class ServerChatWebSocketWorker extends ChatWorker {
   #buffers = []
   #queuedBytes = 0
+  #socketIO = null
   #state = 0
   #writable = 0
   #encoder = new TextEncoder()
@@ -36,6 +37,7 @@ export default class ServerChatWebSocketWorker extends ChatWorker {
     this.ws = null
     this.#buffers = []
     this.#queuedBytes = 0
+    this.#socketIO = null
     this.#state = 0
     this.#writable = 0
     try {
@@ -51,6 +53,7 @@ export default class ServerChatWebSocketWorker extends ChatWorker {
     this.parser.barrier = message.barrier
     const network = this.secure ? device.network.wss : device.network.ws
     const WebSocketClient = network.io ?? device.network.ws.io
+    this.#socketIO = WebSocketClient
     this.ws = new WebSocketClient({
       ...network,
       host: this.host,
@@ -80,24 +83,21 @@ export default class ServerChatWebSocketWorker extends ChatWorker {
       },
       onReadable: (count, options) => {
         const buffer = this.ws.read(count)
+        this.#open()
         if (this.#state === 1) this.read(buffer, options)
       },
       onWritable: (count) => {
         if (!count) return
         this.#writable = count
-        if (this.#state === 0) {
-          this.onOpen()
-          this.#state = 1
-          return
-        }
+        this.#open()
         this.flushWrites()
       },
     })
   }
 
   disconnect() {
-    if (!this.ws) return
-    const WebSocketClient = device.network.ws.io
+    const WebSocketClient = this.#socketIO
+    if (!this.ws || !WebSocketClient) return
     const code = 1000
     this.write(Uint8Array.of(code >> 8, code & 0xff), {
       opcode: WebSocketClient.close,
@@ -115,10 +115,19 @@ export default class ServerChatWebSocketWorker extends ChatWorker {
 
   onJSON(json) {
     const type = json.type
-    if (type in this) this[type](json)
+    const handlers = this.eventHandlers
+    if (typeof type === 'string' && handlers?.[type] === true && typeof this[type] === 'function') {
+      this[type](json)
+    }
   }
 
   onOpen() {}
+
+  #open() {
+    if (this.#state !== 0) return
+    this.#state = 1
+    this.onOpen()
+  }
 
   read(data, options) {
     this.parser.read(data)

--- a/firmware/host/modules/conversation/chat-audioio/server-openai-realtime-model.js
+++ b/firmware/host/modules/conversation/chat-audioio/server-openai-realtime-model.js
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 Shinya Ishikawa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { Encode } from 'ChatAudioIO/Codecs'
+import ServerChatWebSocketWorker from 'stackchanServerChatWebSocketWorker'
+
+const audioPrefix = Object.freeze(
+  new Uint8Array(ArrayBuffer.fromString('{"type":"input_audio_buffer.append","audio":"')),
+  true,
+)
+const audioSuffix = Object.freeze(new Uint8Array(ArrayBuffer.fromString('"}')), true)
+
+export default class ServerOpenAIRealtimeModel extends ServerChatWebSocketWorker {
+  constructor(options) {
+    super(options)
+    this.audioPrefix = audioPrefix
+    this.audioSuffix = audioSuffix
+    this.configurationError = ''
+  }
+
+  configure(message) {
+    try {
+      const endpoint = parseWebSocketEndpoint(message.providerID)
+      const apiKey = String(message.apiKey ?? '')
+      const tools = (message.functions ?? []).map((tool) => ({
+        ...tool,
+        type: 'function',
+        parameters: {
+          ...(tool.parameters ?? { type: 'object', properties: {} }),
+          additionalProperties: false,
+        },
+      }))
+      if (!endpoint.secure && apiKey) {
+        throw new Error('ChatService Bearer authentication requires a wss:// endpoint')
+      }
+      this.secure = endpoint.secure
+      this.host = endpoint.host
+      this.port = endpoint.port
+      this.path = endpoint.path
+      this.headers = apiKey ? [['Authorization', `Bearer ${apiKey}`]] : []
+      this.session = {
+        type: 'realtime',
+        audio: {
+          input: {
+            format: { type: 'audio/pcma' },
+            transcription: { model: 'gpt-live-transcribe', languages: ['ja'] },
+            turn_detection: {
+              type: 'server_vad',
+              threshold: 0.5,
+              prefix_padding_ms: 300,
+              silence_duration_ms: 700,
+              create_response: true,
+              interrupt_response: false,
+            },
+          },
+          output: {
+            format: { type: 'audio/pcm', rate: 24000 },
+            voice: message.voiceID ?? 'marin',
+          },
+        },
+        instructions: message.instructions ?? '',
+        tools,
+        tool_choice: 'auto',
+      }
+    } catch (error) {
+      this.configurationError = String(error?.message ?? error)
+    }
+  }
+
+  connect(message) {
+    if (this.configurationError) {
+      this.postMessage({ id: 'failed', string: this.configurationError })
+      return
+    }
+    super.connect(message)
+  }
+
+  generateId(prefix, length = 21) {
+    const chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+    const value = Array(length - prefix.length)
+      .fill(0)
+      .map(() => chars[Math.floor(Math.random() * chars.length)])
+      .join('')
+    return `${prefix}${value}`
+  }
+
+  isBase64(result, _current, name) {
+    return result?.type === 'response.output_audio.delta' && name === 'delta'
+  }
+
+  postPresentation(message) {
+    try {
+      this.postMessage(message)
+    } catch (error) {
+      trace(`[stackchan-ai] presentation update dropped: ${error}\n`)
+    }
+  }
+
+  sendAudio(message) {
+    const buffer = new Uint8Array(this.inputBuffer, message.offset, message.size)
+    Encode.toAlaw(buffer, buffer)
+    message.size >>= 1
+    super.sendAudio(message)
+  }
+
+  sendFunctionResult(message) {
+    this.sendJSON({
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: message.call,
+        output: JSON.stringify(message.result),
+      },
+      event_id: this.generateId('event_'),
+    })
+    this.sendJSON({ type: 'response.create' })
+  }
+
+  sendText(message) {
+    this.sendJSON({
+      type: 'conversation.item.create',
+      item: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: message.text }],
+      },
+      event_id: this.generateId('event_'),
+    })
+    this.sendJSON({ type: 'response.create' })
+  }
+
+  onJSON(json) {
+    if (json.response?.status === 'failed') {
+      this.postMessage({
+        id: 'failed',
+        string: json.response.status_details?.error?.message ?? `${json.type} failed`,
+      })
+      this.close()
+      return
+    }
+    return super.onJSON(json)
+  }
+
+  'conversation.item.input_audio_transcription.completed'(message) {
+    this.postPresentation({ id: 'receiveInputText', text: message.transcript })
+  }
+
+  'response.output_audio_transcript.delta'(message) {
+    this.postPresentation({
+      id: 'receiveOutputText',
+      text: message.delta,
+      more: true,
+    })
+  }
+
+  'response.output_audio_transcript.done'() {
+    this.postPresentation({ id: 'receiveOutputText', text: '' })
+  }
+
+  'response.created'() {
+    this.postPresentation({ id: 'receiveInputText', text: '', more: true })
+    this.postPresentation({ id: 'receiveOutputText', text: '', more: true })
+    this.post('listen')
+  }
+
+  'response.done'() {
+    this.parser.copy(this.silence)
+    this.parser.done()
+    this.post('speak')
+  }
+
+  'response.output_item.done'(message) {
+    const item = message.item
+    if (item.type !== 'function_call') return
+    this.postMessage({
+      id: 'receiveFunctionCall',
+      call: item.call_id,
+      name: item.name,
+      parameters: JSON.parse(item.arguments),
+    })
+  }
+
+  'session.created'() {
+    this.sendJSON({
+      type: 'session.update',
+      session: this.session,
+      event_id: this.generateId('event_'),
+    })
+  }
+
+  'session.updated'() {
+    this.post('connected')
+  }
+
+  error(message) {
+    this.postMessage({
+      id: 'failed',
+      string: message.error?.message ?? 'Realtime API error',
+    })
+    this.close()
+  }
+
+  'input_audio_buffer.committed'() {}
+  'input_audio_buffer.speech_started'() {}
+  'input_audio_buffer.speech_stopped'() {}
+  'response.output_audio.done'() {}
+}
+
+export function parseWebSocketEndpoint(value) {
+  const endpoint = String(value ?? '').trim()
+  const match = /^(wss?):\/\/([^/:?#]+)(?::(\d+))?(\/[^#]*)?$/.exec(endpoint)
+  if (!match) {
+    throw new Error('ChatService endpoint must use ws:// or wss://')
+  }
+  const secure = match[1] === 'wss'
+  const port = match[3] ? Number.parseInt(match[3], 10) : secure ? 443 : 80
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('ChatService endpoint port is invalid')
+  }
+  return {
+    secure,
+    host: match[2],
+    port,
+    path: match[4] ?? '/',
+  }
+}

--- a/firmware/host/modules/conversation/chat-audioio/server-openai-realtime-model.js
+++ b/firmware/host/modules/conversation/chat-audioio/server-openai-realtime-model.js
@@ -13,6 +13,21 @@ const audioPrefix = Object.freeze(
   true,
 )
 const audioSuffix = Object.freeze(new Uint8Array(ArrayBuffer.fromString('"}')), true)
+const eventHandlers = Object.freeze({
+  'conversation.item.input_audio_transcription.completed': true,
+  error: true,
+  'input_audio_buffer.committed': true,
+  'input_audio_buffer.speech_started': true,
+  'input_audio_buffer.speech_stopped': true,
+  'response.created': true,
+  'response.done': true,
+  'response.output_audio.done': true,
+  'response.output_audio_transcript.delta': true,
+  'response.output_audio_transcript.done': true,
+  'response.output_item.done': true,
+  'session.created': true,
+  'session.updated': true,
+})
 
 export default class ServerOpenAIRealtimeModel extends ServerChatWebSocketWorker {
   constructor(options) {
@@ -20,9 +35,11 @@ export default class ServerOpenAIRealtimeModel extends ServerChatWebSocketWorker
     this.audioPrefix = audioPrefix
     this.audioSuffix = audioSuffix
     this.configurationError = ''
+    this.eventHandlers = eventHandlers
   }
 
   configure(message) {
+    this.configurationError = ''
     try {
       const endpoint = parseWebSocketEndpoint(message.providerID)
       const apiKey = String(message.apiKey ?? '')
@@ -34,8 +51,11 @@ export default class ServerOpenAIRealtimeModel extends ServerChatWebSocketWorker
           additionalProperties: false,
         },
       }))
-      if (!endpoint.secure && apiKey) {
-        throw new Error('ChatService Bearer authentication requires a wss:// endpoint')
+      if (!endpoint.secure && hasEmbeddedCredentials(endpoint.path)) {
+        throw new Error('ChatService credentials must not be embedded in a ws:// endpoint')
+      }
+      if (!endpoint.secure && apiKey && !isTrustedLocalHost(endpoint.host)) {
+        throw new Error('ChatService Bearer authentication over ws:// is restricted to trusted local networks')
       }
       this.secure = endpoint.secure
       this.host = endpoint.host
@@ -208,6 +228,30 @@ export default class ServerOpenAIRealtimeModel extends ServerChatWebSocketWorker
   'input_audio_buffer.speech_started'() {}
   'input_audio_buffer.speech_stopped'() {}
   'response.output_audio.done'() {}
+}
+
+function hasEmbeddedCredentials(path) {
+  return /(?:[?&](?:access[_-]?token|api[_-]?key|authorization|credential|key|secret|token)=)|(?:\/(?:auth|credential|key|secret|token)(?:\/|$))/i.test(
+    path,
+  )
+}
+
+function isTrustedLocalHost(host) {
+  const normalized = host.toLowerCase()
+  if (normalized === 'localhost' || normalized.endsWith('.local')) return true
+  const parts = normalized.split('.')
+  if (parts.length !== 4 || parts.some((part) => !/^\d{1,3}$/.test(part))) return false
+  const octets = parts.map((part) => Number(part))
+  if (octets.some((octet) => octet > 255)) {
+    return false
+  }
+  return (
+    octets[0] === 10 ||
+    octets[0] === 127 ||
+    (octets[0] === 169 && octets[1] === 254) ||
+    (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+    (octets[0] === 192 && octets[1] === 168)
+  )
 }
 
 export function parseWebSocketEndpoint(value) {

--- a/firmware/host/modules/conversation/chat-audioio/server.manifest.json
+++ b/firmware/host/modules/conversation/chat-audioio/server.manifest.json
@@ -1,0 +1,8 @@
+{
+  "modules": {
+    "stackchanServerChatWebSocketWorker": "./server-chat-websocket-worker",
+    "stackchanServerOpenAIRealtime": "./stackchan-server-openai-realtime",
+    "stackchanServerOpenAIRealtimeModel": "./server-openai-realtime-model"
+  },
+  "preload": ["stackchanServerChatWebSocketWorker"]
+}

--- a/firmware/host/modules/conversation/chat-audioio/stackchan-server-openai-realtime.js
+++ b/firmware/host/modules/conversation/chat-audioio/stackchan-server-openai-realtime.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Shinya Ishikawa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import ServerOpenAIRealtimeModel from 'stackchanServerOpenAIRealtimeModel'
+
+new ServerOpenAIRealtimeModel({
+  inputSampleRate: 8000,
+})

--- a/firmware/host/modules/conversation/chat.ts
+++ b/firmware/host/modules/conversation/chat.ts
@@ -13,6 +13,8 @@ export type ChatType = 'deepgramAgent' | 'elevenLabsAgent' | 'googleGeminiLive' 
 
 export type ChatConfig = {
   type: ChatType
+  specifier?: string
+  endpoint?: string
   apiKey?: string
   instructions?: string
   voiceID?: string
@@ -158,10 +160,10 @@ export class ChatService {
       })
     const chatAudioIOConstants = ChatAudioIOCtor as unknown as ChatAudioIOStateConstants
     this.#chat = new ChatAudioIOCtor({
-      specifier: config.type as unknown as string,
+      specifier: config.specifier ?? (config.type as unknown as string),
       instructions: config.instructions,
       voiceID: config.voiceID,
-      providerID: config.providerID,
+      providerID: config.endpoint ?? config.providerID,
       modelID: config.modelID,
       apiKey: config.apiKey,
       functions: functions.length > 0 ? functions : undefined,

--- a/firmware/host/modules/conversation/chat.ts
+++ b/firmware/host/modules/conversation/chat.ts
@@ -163,6 +163,8 @@ export class ChatService {
       specifier: config.specifier ?? (config.type as unknown as string),
       instructions: config.instructions,
       voiceID: config.voiceID,
+      // ChatAudioIO has no endpoint slot. Only an explicit server endpoint is
+      // routed through providerID; ordinary workers keep their provider ID.
       providerID: config.endpoint ?? config.providerID,
       modelID: config.modelID,
       apiKey: config.apiKey,

--- a/firmware/host/modules/conversation/manifest.json
+++ b/firmware/host/modules/conversation/manifest.json
@@ -17,7 +17,10 @@
       }
     },
     "esp32/m5stackchan_cores3": {
-      "include": ["$(MODULES)/network/services/chatAudioIO/manifest.json"],
+      "include": [
+        "$(MODULES)/network/services/chatAudioIO/manifest.json",
+        "./chat-audioio/server.manifest.json"
+      ],
       "modules": {
         "ChatAudioIO": "./chat-audioio/worker-stack",
         "ChatAudioIOBase": "$(MODULES)/network/services/chatAudioIO/ChatAudioIO"


### PR DESCRIPTION
## Summary

- allow `ChatService` callers to select a worker specifier and server endpoint explicitly
- add a server-backed OpenAI Realtime subset adapter for M5StackChan CoreS3
- keep the existing half-duplex `ChatAudioIO` implementation and leave all other hardware targets unchanged
- add a firmware changeset and focused Moddable tests

## Why

stack-chan-ai supplies its own `/device/v1/realtime` WebSocket endpoint. The direct OpenAI worker used by the MOD hardcodes `api.openai.com`, so passing the stack-chan-ai endpoint to that worker does not route audio through the server.

PR #634 contains the server adapter, but also includes duplex/AEC, renderer, diagnostics, and benchmark work that is not required for stack-chan-ai connectivity. This PR extracts only the integration boundary needed by the existing half-duplex pipeline.

## Impact

- Release impact: **minor**
- The new worker modules are included only for `esp32/m5stackchan_cores3`.
- Existing chat providers and non-CoreS3 targets keep their current behavior.

## Validation

- `npm run format`
- `npm run lint` (passes; one pre-existing informational finding)
- `npm run test:unit`
- `npm run check:architecture` (73 passed)
- `npm run check:manifest` (6 targets passed)
- focused Moddable tests for `chat-service` and `server-realtime-model`
- `npm run build:m5stackchan_cores3`
- M5StackChan CoreS3 hardware smoke on MAC `44:1b:f6:e2:99:a4`: Wi-Fi, control WebSocket, server-backed Realtime worker, transcription/history persistence, and TTS verified through the fourth voice turn without a reboot or debugger exception


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added server-backed real-time voice conversations for M5StackChan CoreS3.
  - Added WebSocket connectivity for streaming audio, transcripts, responses, and function calls.
  - Added support for configurable conversation providers, endpoints, audio formats, voice settings, transcription, and turn detection.
  - Added secure and non-secure WebSocket endpoint support with connection and error handling.
  - Added configuration options to select conversation adapters and service endpoints. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->