### PR TITLE
fix: update vulnerable web dependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2512,9 +2512,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2633,7 +2633,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- Refresh vulnerable transitive web dependencies to restore the audit CI on `develop`.

## Root Cause

- The web lockfile pinned `postcss@8.5.22` and `nanoid@3.3.16`.
- The newly published `nanoid <3.3.17` high-severity advisory caused `npm audit --audit-level=high` to fail in the `web-visual` job.

## What Changed

- Updated `postcss` from 8.5.22 to 8.5.26.
- Updated `nanoid` from 3.3.16 to 3.3.18.
- Kept the change limited to `web/package-lock.json`.

## Verification

- [ ] `cd firmware && npm run format`
- [ ] `cd firmware && npm run lint`
- [ ] `cd firmware && npm run test`
- [ ] `cd firmware && npm run check:legacy-names`
- [x] Other checks were run when relevant
  - `cd web && npm ci`
  - `cd web && npm audit --audit-level=high` (0 vulnerabilities)
  - `cd web && npm test` (207 Node tests and 40 Vitest tests passed)
  - `cd web && npm run build`
  - `git diff --check`

## Affected Areas

- [ ] firmware
- [x] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Release Impact

- `none`
- No changeset is needed because this only refreshes transitive development/build dependencies in the web lockfile; it does not change shipped source behavior.

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

- None
