### PR TITLE
Bundle uppercase glyphs and QR renderer in host firmware

### DIFF
--- a/.changeset/warm-uppercase-device-code.md
+++ b/.changeset/warm-uppercase-device-code.md
@@ -2,4 +2,4 @@
 "stack-chan": patch
 ---
 
-Restore uppercase Latin glyphs in the 24px UI font for device and WASM builds so authorization codes render completely.
+Restore uppercase Latin glyphs and bundle the QR code renderer in device and WASM hosts so authorization codes and activation links render without a custom host overlay.

--- a/.changeset/warm-uppercase-device-code.md
+++ b/.changeset/warm-uppercase-device-code.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Restore uppercase Latin glyphs in the 24px UI font for device and WASM builds so authorization codes render completely.

--- a/firmware/host/app/bundle-manifest.architecture.ts
+++ b/firmware/host/app/bundle-manifest.architecture.ts
@@ -14,8 +14,11 @@ type FontResource = {
 
 type FontManifest = {
   build?: { NAME?: string }
+  include?: string[]
   resources?: { '*-alpha'?: FontResource[]; '*-mask'?: Array<string | FontResource> }
 }
+
+const qrCodeManifest = '$(MODDABLE)/modules/piu/MC/qrcode/manifest.json'
 
 const manifest = JSON.parse(readFileSync('host/app/manifest.json', 'utf8')) as FontManifest
 const wasmManifest = JSON.parse(readFileSync('host/app/manifest_wasm.json', 'utf8')) as FontManifest
@@ -47,6 +50,11 @@ function sortedGlyphs(characters: string): string[] {
 test('host manifests use a stable application name', () => {
   assert.equal(manifest.build?.NAME, 'stack-chan-host')
   assert.equal(wasmManifest.build?.NAME, 'stack-chan-host')
+})
+
+test('host manifests bundle the QR code renderer for MODs', () => {
+  assert.ok(manifest.include?.includes(qrCodeManifest))
+  assert.ok(wasmManifest.include?.includes(qrCodeManifest))
 })
 
 test('the 24px font bundles UI glyphs and uppercase Latin letters', () => {

--- a/firmware/host/app/bundle-manifest.architecture.ts
+++ b/firmware/host/app/bundle-manifest.architecture.ts
@@ -61,7 +61,10 @@ test('the 24px font bundles UI glyphs and uppercase Latin letters', () => {
   const requiredCharacters = requireFontCharacters(splashTestManifest, 'startup splash')
   const appBarCharacters = requireFontCharacters(appBarTestManifest, 'AppBar')
   const uppercaseLatin = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  assert.deepEqual(sortedGlyphs(font.characters as string), sortedGlyphs(requiredCharacters + appBarCharacters + uppercaseLatin))
+  assert.deepEqual(
+    sortedGlyphs(font.characters as string),
+    sortedGlyphs(requiredCharacters + appBarCharacters + uppercaseLatin),
+  )
 
   const wasmFont = findFont(
     wasmManifest.resources?.['*-alpha'],

--- a/firmware/host/app/bundle-manifest.architecture.ts
+++ b/firmware/host/app/bundle-manifest.architecture.ts
@@ -49,7 +49,7 @@ test('host manifests use a stable application name', () => {
   assert.equal(wasmManifest.build?.NAME, 'stack-chan-host')
 })
 
-test('the 24px font bundles glyphs used by the splash title and AppBar clock', () => {
+test('the 24px font bundles UI glyphs and uppercase Latin letters', () => {
   const font = findFont(
     manifest.resources?.['*-alpha'],
     (resource) => resource.source === '../modules/ui/assets/fonts/k8x12' && resource.size === 24,
@@ -60,7 +60,8 @@ test('the 24px font bundles glyphs used by the splash title and AppBar clock', (
   assert.equal(font.characterFiles, undefined)
   const requiredCharacters = requireFontCharacters(splashTestManifest, 'startup splash')
   const appBarCharacters = requireFontCharacters(appBarTestManifest, 'AppBar')
-  assert.deepEqual(sortedGlyphs(font.characters as string), sortedGlyphs(requiredCharacters + appBarCharacters))
+  const uppercaseLatin = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  assert.deepEqual(sortedGlyphs(font.characters as string), sortedGlyphs(requiredCharacters + appBarCharacters + uppercaseLatin))
 
   const wasmFont = findFont(
     wasmManifest.resources?.['*-alpha'],

--- a/firmware/host/app/bundle-manifest.architecture.ts
+++ b/firmware/host/app/bundle-manifest.architecture.ts
@@ -14,11 +14,8 @@ type FontResource = {
 
 type FontManifest = {
   build?: { NAME?: string }
-  include?: string[]
   resources?: { '*-alpha'?: FontResource[]; '*-mask'?: Array<string | FontResource> }
 }
-
-const qrCodeManifest = '$(MODDABLE)/modules/piu/MC/qrcode/manifest.json'
 
 const manifest = JSON.parse(readFileSync('host/app/manifest.json', 'utf8')) as FontManifest
 const wasmManifest = JSON.parse(readFileSync('host/app/manifest_wasm.json', 'utf8')) as FontManifest
@@ -50,11 +47,6 @@ function sortedGlyphs(characters: string): string[] {
 test('host manifests use a stable application name', () => {
   assert.equal(manifest.build?.NAME, 'stack-chan-host')
   assert.equal(wasmManifest.build?.NAME, 'stack-chan-host')
-})
-
-test('host manifests bundle the QR code renderer for MODs', () => {
-  assert.ok(manifest.include?.includes(qrCodeManifest))
-  assert.ok(wasmManifest.include?.includes(qrCodeManifest))
 })
 
 test('the 24px font bundles UI glyphs and uppercase Latin letters', () => {

--- a/firmware/host/app/manifest.json
+++ b/firmware/host/app/manifest.json
@@ -111,7 +111,7 @@
       {
         "source": "../modules/ui/assets/fonts/k8x12",
         "size": 24,
-        "characters": "Stack-chan[・＿・]0123456789:",
+        "characters": "Stack-chan[・＿・]0123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "monochrome": true
       }
     ]

--- a/firmware/host/app/manifest.json
+++ b/firmware/host/app/manifest.json
@@ -17,7 +17,6 @@
     "../modules/camera/manifest.json",
     "../modules/lighting/manifest.json",
     "../modules/ui/manifest.json",
-    "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json",
     "../modules/input/manifest.json",
     "../modules/util/manifest.json",
     "../modules/preferences/manifest.json",

--- a/firmware/host/app/manifest.json
+++ b/firmware/host/app/manifest.json
@@ -17,6 +17,7 @@
     "../modules/camera/manifest.json",
     "../modules/lighting/manifest.json",
     "../modules/ui/manifest.json",
+    "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json",
     "../modules/input/manifest.json",
     "../modules/util/manifest.json",
     "../modules/preferences/manifest.json",

--- a/firmware/host/app/manifest_wasm.json
+++ b/firmware/host/app/manifest_wasm.json
@@ -2,7 +2,10 @@
   "build": {
     "NAME": "stack-chan-host"
   },
-  "include": ["../platforms/wasm/manifest.json"],
+  "include": [
+    "../platforms/wasm/manifest.json",
+    "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json"
+  ],
   "resources": {
     "*": ["./strings/*"],
     "*-mask": [

--- a/firmware/host/app/manifest_wasm.json
+++ b/firmware/host/app/manifest_wasm.json
@@ -2,10 +2,7 @@
   "build": {
     "NAME": "stack-chan-host"
   },
-  "include": [
-    "../platforms/wasm/manifest.json",
-    "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json"
-  ],
+  "include": ["../platforms/wasm/manifest.json"],
   "resources": {
     "*": ["./strings/*"],
     "*-mask": [

--- a/firmware/host/app/manifest_wasm.json
+++ b/firmware/host/app/manifest_wasm.json
@@ -28,7 +28,7 @@
       {
         "source": "../modules/ui/assets/fonts/k8x12",
         "size": 24,
-        "characters": "Stack-chan[・＿・]0123456789:",
+        "characters": "Stack-chan[・＿・]0123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         "monochrome": true
       }
     ]

--- a/firmware/host/modules/ui/application/app-controller.architecture.ts
+++ b/firmware/host/modules/ui/application/app-controller.architecture.ts
@@ -9,9 +9,18 @@ const legacyCompatName = ['Renderer', 'Compat'].join('')
 const legacyModulePaths = ['simple', 'small', 'dog', 'image', 'compat'].map(
   (name) => `host/modules/ui/application/${legacyPrefix}${name}.ts`,
 )
+const uiManifestPaths = ['host/modules/ui/manifest.json', 'host/modules/ui/manifest_wasm.json']
+const qrCodeManifest = '$(MODDABLE)/modules/piu/MC/qrcode/manifest.json'
+
+test('UI manifests bundle the QR code renderer for MODs', () => {
+  for (const manifestPath of uiManifestPaths) {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { include?: string[] }
+    assert.ok(manifest.include?.includes(qrCodeManifest), manifestPath)
+  }
+})
 
 test('UI manifests do not expose legacy renderer adapter modules', () => {
-  for (const manifestPath of ['host/modules/ui/manifest.json', 'host/modules/ui/manifest_wasm.json']) {
+  for (const manifestPath of uiManifestPaths) {
     const source = readFileSync(manifestPath, 'utf8')
     assert.doesNotMatch(source, new RegExp(legacyPrefix))
     assert.doesNotMatch(source, new RegExp(legacyCompatName))

--- a/firmware/host/modules/ui/manifest.json
+++ b/firmware/host/modules/ui/manifest.json
@@ -5,6 +5,7 @@
     "$(MODDABLE)/examples/manifest_piu.json",
     "$(MODDABLE)/modules/input/expanding-keyboard/horizontal/manifest.json",
     "$(MODDABLE)/modules/piu/MC/outline/manifest.json",
+    "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json",
     "$(MODULES)/commodetto/outline/manifest.json",
     "../util/manifest.json"
   ],

--- a/firmware/host/modules/ui/manifest_wasm.json
+++ b/firmware/host/modules/ui/manifest_wasm.json
@@ -5,6 +5,7 @@
     "$(MODDABLE)/examples/manifest_piu.json",
     "$(MODDABLE)/modules/input/expanding-keyboard/horizontal/manifest.json",
     "$(MODDABLE)/modules/piu/MC/outline/manifest.json",
+    "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json",
     "$(MODULES)/commodetto/outline/manifest.json",
     "../util/manifest.json"
   ],


### PR DESCRIPTION
## What changed

- Bundle `A-Z` in the `k8x12-24` font resource for both device and WASM host manifests.
- Extend the existing manifest architecture test to require uppercase Latin glyphs and preserve device/WASM parity.
- Bundle Moddable's `piu/QRCode` renderer in the device and WASM UI manifests so MODs can render activation links without a custom host overlay.

## Why

The 24px font subset only contained the Stack-chan title, digits, and punctuation. UI strings such as device authorization codes therefore rendered their hyphen and digits while omitting most uppercase letters.

The shared UI manifests also did not bundle `piu/QRCode`, so device-flow MODs required a custom host overlay before they could draw activation QR codes.

## Release impact

`patch` — `.changeset/warm-uppercase-device-code.md` records the user-visible device/WASM font and QR renderer fixes.

## Impact

Uppercase codes and other uppercase UI text can now render with the existing fixed-width 24px font without changing layout metrics.
Device-flow MODs can render activation QR codes against the standard device and WASM hosts.

## Validation

- `npm run check:architecture` — 74 tests passed
- `source ~/.local/share/xs-dev-export.sh && npm run check:manifest` — 6 targets passed
- `npm run lint` — passed (one pre-existing informational notice)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QR code rendering support to standard device and WASM hosts.
  * Expanded supported font characters to include uppercase Latin letters (A–Z) across standard and WASM resources.

* **Tests**
  * Updated font validation to verify uppercase letter rendering.
  * Confirmed QR code renderer availability across supported host environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->