### PR TITLE
Keep CoreS3 speaker and microphone half-duplex on I2S1

### DIFF
--- a/.changeset/calm-cores3-i2s-half-duplex.md
+++ b/.changeset/calm-cores3-i2s-half-duplex.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Keep CoreS3 speaker and microphone half-duplex on I2S1, drop speaker MCLK from GPIO0, and start or stop AW88298 and ES7210 when the bus owner changes.

--- a/firmware/host/modules/audio/__tests__/audio-buffer-ownership.architecture.ts
+++ b/firmware/host/modules/audio/__tests__/audio-buffer-ownership.architecture.ts
@@ -60,6 +60,9 @@ test('M5StackChan CoreS3 excludes the fallback stackchan-voice module before sel
 
   assert.equal(modules['~'], './tts-stackchan-voice')
   assert.equal(modules['tts-stackchan-voice'], './stackchan-voice/tts-stackchan-voice')
+  assert.equal(modules['embedded:io/audio/out-original'], './platforms/m5stackchan-cores3/io-audioout/audioout-esp32')
+  assert.equal(modules['embedded:io/audio/out'], './platforms/m5stackchan-cores3/cores3-audio-out')
+  assert.equal(modules['embedded:io/audio/in'], './platforms/m5stackchan-cores3/cores3-audio-in')
 })
 
 test('conversation modules stay independent of app layer contracts', () => {

--- a/firmware/host/modules/audio/__tests__/cores3-i2s-bus.test.ts
+++ b/firmware/host/modules/audio/__tests__/cores3-i2s-bus.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { CoreS3I2SBus } from '../platforms/m5stackchan-cores3/cores3-i2s-bus.ts'
+
+test('acquiring the other role stops the previous codec before starting the next', () => {
+  const events: string[] = []
+  const bus = new CoreS3I2SBus({
+    startSpeaker: (sampleRate) => events.push(`startSpeaker:${sampleRate}`),
+    stopSpeaker: () => events.push('stopSpeaker'),
+    startMicrophone: (sampleRate) => events.push(`startMicrophone:${sampleRate}`),
+    stopMicrophone: () => events.push('stopMicrophone'),
+  })
+
+  bus.acquire('microphone', 16000)
+  bus.acquire('speaker', 24000)
+
+  assert.equal(bus.owner, 'speaker')
+  assert.deepEqual(events, ['startMicrophone:16000', 'stopMicrophone', 'startSpeaker:24000'])
+})
+
+test('release only stops the current owner', () => {
+  const events: string[] = []
+  const bus = new CoreS3I2SBus({
+    startSpeaker: () => events.push('startSpeaker'),
+    stopSpeaker: () => events.push('stopSpeaker'),
+    startMicrophone: () => events.push('startMicrophone'),
+    stopMicrophone: () => events.push('stopMicrophone'),
+  })
+
+  bus.acquire('speaker', 24000)
+  bus.release('microphone')
+  assert.equal(bus.owner, 'speaker')
+  bus.release('speaker')
+  assert.equal(bus.owner, 'idle')
+  assert.deepEqual(events, ['startSpeaker', 'stopSpeaker'])
+})

--- a/firmware/host/modules/audio/__tests__/cores3-i2s-overlay.architecture.ts
+++ b/firmware/host/modules/audio/__tests__/cores3-i2s-overlay.architecture.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+test('CoreS3 AudioOut overlay uses the manifest I2S port and IDF slot macros', () => {
+  const source = readFileSync('host/modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32.c', 'utf8')
+
+  assert.match(source, /I2S_CHANNEL_DEFAULT_CONFIG\(MODDEF_AUDIOOUT_I2S_NUM/)
+  assert.doesNotMatch(source, /I2S_CHANNEL_DEFAULT_CONFIG\(I2S_NUM_AUTO/)
+  assert.match(source, /I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG/)
+  assert.match(source, /I2S_STD_MSB_SLOT_DEFAULT_CONFIG/)
+})
+
+test('CoreS3 AudioIn overlay creates the RX channel without enabling it', () => {
+  const source = readFileSync('host/modules/audio/platforms/m5stackchan-cores3/io-audioin/audioin.c', 'utf8')
+
+  assert.match(source, /audioInOpenStdChannel/)
+  assert.match(source, /Leave the RX channel in READY until start/)
+  assert.doesNotMatch(
+    source,
+    /err = i2s_channel_enable\(input->handle\);\s*\n\s*if \(err\) \{\s*\n\s*i2s_del_channel\(input->handle\);\s*\n\s*input->handle = C_NULL;/,
+  )
+})
+
+test('CoreS3 AudioOut define drops speaker MCLK and selects Philips I2S on I2S1', () => {
+  const manifest = JSON.parse(readFileSync('host/modules/audio/manifest.json', 'utf8')) as {
+    platforms: Record<string, { defines?: { audioOut?: { i2s?: Record<string, unknown> } } }>
+  }
+  const i2s = manifest.platforms['esp32/m5stackchan_cores3'].defines?.audioOut?.i2s
+
+  assert.equal(i2s?.num, 1)
+  assert.equal(i2s?.format_i2s, 1)
+  assert.equal(i2s?.mck_pin, -1)
+  assert.equal(i2s?.bck_pin, 34)
+  assert.equal(i2s?.lr_pin, 33)
+  assert.equal(i2s?.dataout_pin, 13)
+})

--- a/firmware/host/modules/audio/manifest.json
+++ b/firmware/host/modules/audio/manifest.json
@@ -137,7 +137,12 @@
         "buffered-mp3streamer-core": "./platforms/m5stackchan-cores3/buffered-mp3streamer",
         "web-radio-byte-ring": "./platforms/m5stackchan-cores3/shared-byte-ring",
         "web-radio-stream-worker": "./platforms/m5stackchan-cores3/web-radio-stream-worker",
-        "embedded:io/audio/in": "$(MODDABLE)/modules/io/audioin/esp32/audioin",
+        "stackchanCores3AudioOutNative": "./platforms/m5stackchan-cores3/io-audioout/audioout-esp32",
+        "stackchanCores3AudioInNative": "./platforms/m5stackchan-cores3/io-audioin/audioin",
+        "cores3I2SBus": "./platforms/m5stackchan-cores3/cores3-i2s-bus",
+        "embedded:io/audio/out-original": "./platforms/m5stackchan-cores3/io-audioout/audioout-esp32",
+        "embedded:io/audio/out": "./platforms/m5stackchan-cores3/cores3-audio-out",
+        "embedded:io/audio/in": "./platforms/m5stackchan-cores3/cores3-audio-in",
         "tts-stackchan-voice": "./stackchan-voice/tts-stackchan-voice"
       },
       "dependency": [
@@ -154,7 +159,17 @@
         "audioOut": {
           "bitsPerSample": 16,
           "numChannels": 1,
-          "sampleRate": 24000
+          "sampleRate": 24000,
+          "i2s": {
+            "num": 1,
+            "slot": "I2S_STD_SLOT_LEFT",
+            "format_i2s": 1,
+            "bitsPerSample": 16,
+            "bck_pin": 34,
+            "lr_pin": 33,
+            "mck_pin": -1,
+            "dataout_pin": 13
+          }
         }
       }
     },

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/cores3-audio-in.js
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/cores3-audio-in.js
@@ -1,0 +1,33 @@
+import AudioIn from 'stackchanCores3AudioInNative'
+import { cores3I2SBus } from 'cores3I2SBus'
+
+export default class CoreS3AudioIn extends AudioIn {
+  constructor(options) {
+    cores3I2SBus.acquire('microphone', options?.sampleRate)
+    try {
+      super(options)
+    } catch (error) {
+      cores3I2SBus.release('microphone')
+      throw error
+    }
+  }
+
+  start() {
+    cores3I2SBus.acquire('microphone', this.sampleRate)
+    return super.start()
+  }
+
+  stop() {
+    const result = super.stop()
+    cores3I2SBus.release('microphone')
+    return result
+  }
+
+  close() {
+    try {
+      return super.close()
+    } finally {
+      cores3I2SBus.release('microphone')
+    }
+  }
+}

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/cores3-audio-out.js
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/cores3-audio-out.js
@@ -1,0 +1,34 @@
+import AudioOut from 'stackchanCores3AudioOutNative'
+import { cores3I2SBus } from 'cores3I2SBus'
+
+export default class CoreS3AudioOut extends AudioOut {
+  constructor(options) {
+    cores3I2SBus.acquire('speaker', options?.sampleRate)
+    try {
+      super(options)
+    } catch (error) {
+      cores3I2SBus.release('speaker')
+      throw error
+    }
+    cores3I2SBus.acquire('speaker', this.sampleRate)
+  }
+
+  start() {
+    cores3I2SBus.acquire('speaker', this.sampleRate)
+    return super.start()
+  }
+
+  stop() {
+    const result = super.stop()
+    cores3I2SBus.release('speaker')
+    return result
+  }
+
+  close() {
+    try {
+      return super.close()
+    } finally {
+      cores3I2SBus.release('speaker')
+    }
+  }
+}

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/cores3-i2s-bus.ts
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/cores3-i2s-bus.ts
@@ -1,0 +1,109 @@
+export type CoreS3I2SRole = 'speaker' | 'microphone'
+export type CoreS3I2SOwner = 'idle' | CoreS3I2SRole
+
+export type CoreS3I2SCodec = {
+  startSpeaker?(sampleRate: number): void
+  stopSpeaker?(): void
+  startMicrophone?(sampleRate: number): void
+  stopMicrophone?(): void
+}
+
+export class CoreS3I2SBus {
+  #owner: CoreS3I2SOwner = 'idle'
+  #codec: CoreS3I2SCodec
+
+  constructor(codec: CoreS3I2SCodec = {}) {
+    this.#codec = codec
+  }
+
+  get owner(): CoreS3I2SOwner {
+    return this.#owner
+  }
+
+  acquire(role: CoreS3I2SRole, sampleRate?: number): void {
+    if (this.#owner === role) {
+      this.#start(role, sampleRate)
+      return
+    }
+    this.#stop(this.#owner)
+    this.#owner = 'idle'
+    this.#start(role, sampleRate)
+    this.#owner = role
+  }
+
+  release(role: CoreS3I2SRole): void {
+    if (this.#owner !== role) return
+    this.#stop(role)
+    this.#owner = 'idle'
+  }
+
+  #start(role: CoreS3I2SRole, sampleRate?: number): void {
+    if (role === 'speaker') this.#codec.startSpeaker?.(sampleRate ?? 24000)
+    else this.#codec.startMicrophone?.(sampleRate ?? 16000)
+  }
+
+  #stop(owner: CoreS3I2SOwner): void {
+    if (owner === 'speaker') this.#codec.stopSpeaker?.()
+    else if (owner === 'microphone') this.#codec.stopMicrophone?.()
+  }
+}
+
+function startSpeaker(sampleRate: number): void {
+  const amp = globalThis.amp as { sampleRate?: number } | undefined
+  if (amp) amp.sampleRate = sampleRate
+  writeAmpSysCtrl(0x4040)
+}
+
+function stopSpeaker(): void {
+  writeAmpSysCtrl(0x0040)
+}
+
+function startMicrophone(_sampleRate: number): void {
+  const mic = globalThis.mic as { init?: () => void } | undefined
+  mic?.init?.()
+}
+
+function stopMicrophone(): void {
+  writeMicReset()
+}
+
+function writeAmpSysCtrl(value: number): void {
+  const io = openInternalSMBus(0x36)
+  io?.writeUint16?.(0x04, value, true)
+}
+
+function writeMicReset(): void {
+  const io = openInternalSMBus(0x40)
+  io?.writeUint8?.(0x00, 0xff)
+}
+
+function openInternalSMBus(
+  address: number,
+):
+  | {
+      writeUint16?(register: number, value: number, littleEndian?: boolean): void
+      writeUint8?(register: number, value: number): void
+    }
+  | undefined {
+  const device = globalThis.device as
+    | {
+        io?: { SMBus?: new (options: Record<string, unknown>) => object }
+        I2C?: { internal?: Record<string, unknown> }
+      }
+    | undefined
+  const Bus = device?.io?.SMBus
+  const internal = device?.I2C?.internal
+  if (!Bus || !internal) return undefined
+  try {
+    return new Bus({ hz: 400_000, address, ...internal })
+  } catch {
+    return undefined
+  }
+}
+
+export const cores3I2SBus = new CoreS3I2SBus({
+  startSpeaker,
+  stopSpeaker,
+  startMicrophone,
+  stopMicrophone,
+})

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioin/audioin.c
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioin/audioin.c
@@ -1,0 +1,853 @@
+/*
+ * Stack-chan overlay of Moddable modules/io/audioin/esp32/audioin.c.
+ * Opens the RX channel in READY and enables it only after start().
+ *
+ * Copyright (c) 2024-2025 Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ * 
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.  
+ *
+ */
+
+#include "xsmc.h"
+#include "xsHost.h"
+#include "mc.xs.h"
+#include "mc.defines.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "driver/i2s_std.h"
+#include "driver/i2s_pdm.h"
+#include "esp_adc/adc_continuous.h"
+#include "soc/soc_caps.h"
+
+#include "builtinCommon.h"
+
+#ifndef MODDEF_AUDIOIN_I2S_NUM
+	#define MODDEF_AUDIOIN_I2S_NUM			(0)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_BCK_PIN
+	#define MODDEF_AUDIOIN_I2S_BCK_PIN		(32)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_LR_PIN
+	#define MODDEF_AUDIOIN_I2S_LR_PIN		(33)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_MCK_PIN
+	#define MODDEF_AUDIOIN_I2S_MCK_PIN		(I2S_GPIO_UNUSED)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_FORMAT_I2S
+	#define MODDEF_AUDIOIN_I2S_FORMAT_I2S	(0)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_DATAIN
+	#define MODDEF_AUDIOIN_I2S_DATAIN		(27)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_ADC
+	#define MODDEF_AUDIOIN_I2S_ADC			(0)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_MULTIPLIER
+	#define MODDEF_AUDIOIN_I2S_MULTIPLIER	(1)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_BIAS
+	#define MODDEF_AUDIOIN_I2S_BIAS			(0)
+#endif
+#ifndef MODDEF_AUDIOIN_I2S_SLOT
+	#define MODDEF_AUDIOIN_I2S_SLOT (I2S_STD_SLOT_RIGHT)
+#endif
+#ifndef MODDEF_AUDIOIN_NUMCHANNELS
+	#define MODDEF_AUDIOIN_NUMCHANNELS (1)
+#endif
+
+#if MODDEF_AUDIOIN_I2S_ADC
+	#if MODDEF_AUDIOIN_SAMPLERATE < SOC_ADC_SAMPLE_FREQ_THRES_LOW
+		#warning "SOC reqires higher audioin sample rate. automatically increasing."
+		#undef MODDEF_AUDIOIN_SAMPLERATE
+		#define MODDEF_AUDIOIN_SAMPLERATE SOC_ADC_SAMPLE_FREQ_THRES_LOW
+	#elif MODDEF_AUDIOIN_SAMPLERATE > SOC_ADC_SAMPLE_FREQ_THRES_HIGH
+		#warning "SOC requires lower audioin sample rate. automatically decreasing."
+		#undef MODDEF_AUDIOIN_SAMPLERATE
+		#define MODDEF_AUDIOIN_SAMPLERATE SOC_ADC_SAMPLE_FREQ_THRES_HIGH
+	#endif
+#endif
+
+#if MODDEF_AUDIOIN_I2S_PDM
+	uint8_t gPDMAudioOutBusy __attribute__((weak)) = 0;
+	uint8_t gPDMAudioInBusy = 0;
+#endif
+
+#define kADCSampleLength	(256)
+
+#define AUDIO_IN_TIMEOUT	50
+#define MAX_INPUT_BLOCK		2048
+#define AUDIO_IN_BUFFERSIZE	(8192 * 2)
+#define AUDIO_IN_DMA_FRAMES	240
+
+enum {
+	kStateIdle = 0,
+	kStateRecording = 1,
+	kStateClosing = 2,
+	kStateTerminated = 3
+};
+
+struct AudioInputRecord {
+	xsMachine	*the;
+	xsSlot		object;
+	xsSlot		*onReadable;
+	uint8_t		pendingCallback;
+
+	uint8_t		numChannels;
+	uint32_t	sampleRate;
+	uint32_t	bitsPerSample;
+
+#if MODDEF_AUDIOIN_I2S_ADC
+	adc_continuous_handle_t handle;
+#else
+	i2s_chan_handle_t handle;
+#endif
+
+	SemaphoreHandle_t	mutex;
+	TaskHandle_t		task;
+	uint8_t		state;
+
+	uint8_t		*recPos;
+	uint8_t		*playPos;
+	uint8_t		*endPos;
+	uint32_t	bufferSize;
+	uint32_t	dmaReadBytes;
+	uint8_t		buffer[];
+};
+typedef struct AudioInputRecord AudioInputRecord;
+typedef struct AudioInputRecord *AudioInput;
+
+#if 0 && mxInstrument
+	#include "modInstrumentation.h"
+	#define countBytes	modInstrumentationAdjust
+#else
+	#define countBytes(what, value)
+#endif
+
+static void xs_audioin_mark(xsMachine* the, void* it, xsMarkRoot markRoot);
+static void audioInLoop(void *pvParameter);
+static void deliverCallbacks(void *the, void *refcon, uint8_t *message, uint16_t messageLength);
+
+/*
+static void blockDump(uint8_t *block, uint32_t amt)
+{
+	char debugStr[128];
+	int i;
+	uint16_t *blk = (uint16_t*)block;
+	char *pos = debugStr;
+
+	for (i=0; i<amt/2; i++) {
+		pos += sprintf(pos, "%04x ", *blk++);
+		if (i % 16 == 15) {
+			modLog_transmit(debugStr);
+			pos = debugStr;
+		}
+	}
+	if (pos != debugStr)
+		modLog_transmit(debugStr);
+}
+*/
+
+static const xsHostHooks xsAudioInHooks = {
+	xs_audioin_destructor,
+	xs_audioin_mark,
+	C_NULL
+};
+
+static int amtReadable(AudioInput input) {
+	int p = input->recPos - input->playPos;
+	if (p < 0)
+		p += input->bufferSize;
+	return p;
+}
+
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+static void audioInCloseChannel(AudioInput input)
+{
+	if (!input->handle)
+		return;
+	if (ESP_OK == i2s_del_channel(input->handle))
+		input->handle = C_NULL;
+}
+
+static esp_err_t audioInOpenStdChannel(AudioInput input)
+{
+	esp_err_t err;
+	i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(MODDEF_AUDIOIN_I2S_NUM, I2S_ROLE_MASTER);
+	i2s_std_config_t rx_std_cfg = {
+		.clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(input->sampleRate),
+#if MODDEF_AUDIOIN_I2S_FORMAT_I2S
+		.slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT,
+			(2 == MODDEF_AUDIOIN_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO),
+#else
+		.slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT,
+			(2 == MODDEF_AUDIOIN_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO),
+#endif
+		.gpio_cfg = {
+			.mclk = MODDEF_AUDIOIN_I2S_MCK_PIN,
+			.bclk = MODDEF_AUDIOIN_I2S_BCK_PIN,
+			.ws = MODDEF_AUDIOIN_I2S_LR_PIN,
+			.dout = I2S_GPIO_UNUSED,
+			.din = MODDEF_AUDIOIN_I2S_DATAIN,
+			.invert_flags = {
+				.mclk_inv = false,
+				.bclk_inv = false,
+				.ws_inv = false,
+			}
+		}
+	};
+
+	chan_cfg.dma_desc_num = 6;
+	chan_cfg.dma_frame_num = AUDIO_IN_DMA_FRAMES;
+	input->handle = C_NULL;
+	err = i2s_new_channel(&chan_cfg, C_NULL, &input->handle);
+	if (ESP_OK != err) {
+		input->handle = C_NULL;
+		return err;
+	}
+
+	rx_std_cfg.slot_cfg.slot_mask = (2 == MODDEF_AUDIOIN_NUMCHANNELS)
+		? I2S_STD_SLOT_BOTH
+		: MODDEF_AUDIOIN_I2S_SLOT;
+	err = i2s_channel_init_std_mode(input->handle, &rx_std_cfg);
+	if (ESP_OK != err) {
+		audioInCloseChannel(input);
+		return err;
+	}
+	return ESP_OK;
+}
+#endif
+
+void xs_audioin_constructor(xsMachine *the)
+{
+	uint8_t format = kIOFormatBuffer;
+	int32_t bitsPerSample = 16;
+	int32_t numChannels = 1;
+	int32_t sampleRate = 8000;
+	uint32_t bytesPerFrame, bufferSize;
+	AudioInput input;
+	int i;
+	xsmcVars(1);
+
+#ifdef MODDEF_AUDIOIN_BITSPERSAMPLE
+	bitsPerSample = MODDEF_AUDIOIN_BITSPERSAMPLE;
+#endif
+#ifdef MODDEF_AUDIOIN_NUMCHANNELS
+	numChannels = MODDEF_AUDIOIN_NUMCHANNELS;
+#endif
+#ifdef MODDEF_AUDIOIN_SAMPLERATE
+	sampleRate = MODDEF_AUDIOIN_SAMPLERATE;
+#endif
+	format = builtinInitializeFormat(the, format);
+	if (kIOFormatBuffer != format)
+		xsRangeError("invalid format");
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_bitsPerSample))
+		bitsPerSample = xsmcToInteger(xsVar(0));
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_channels))
+		numChannels = xsmcToInteger(xsVar(0));
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_sampleRate))
+		sampleRate = xsmcToInteger(xsVar(0));
+	if ((8 != bitsPerSample) && (16 != bitsPerSample))
+		xsRangeError("invalid bits per sample");
+	if ((1 != numChannels) && (2 != numChannels))
+		xsRangeError("invalid number of channels");
+	if ((sampleRate < 8000) || (sampleRate > 48000))
+		xsRangeError("invalid sample rate");
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_audioType)) {
+		char *type = xsmcToString(xsVar(0));
+		if (c_strcmp(type, "LPCM"))
+			xsRangeError("invalid audioType");
+	}
+
+
+#if MODDEF_AUDIOIN_I2S_PDM
+	if (gPDMAudioInBusy)
+		xsUnknownError("already in use");
+
+	if (gPDMAudioOutBusy)
+		xsUnknownError("pdm already in use by audioout");
+#endif
+
+	bytesPerFrame = (bitsPerSample * numChannels) >> 3;
+//	bufferSize = (bytesPerFrame * sampleRate) >> 5; //??
+	bufferSize = AUDIO_IN_BUFFERSIZE;
+
+	input = (AudioInput)c_calloc(1, sizeof(AudioInputRecord) + bufferSize);
+	if (!input)
+		xsRangeError("not enough memory");
+	xsmcSetHostData(xsThis, input);
+	xsSetHostHooks(xsThis, (xsHostHooks *)&xsAudioInHooks);
+
+	input->state = kStateIdle;
+	input->bufferSize = bufferSize;
+	input->recPos = input->buffer;
+	input->playPos = input->buffer;
+	input->endPos = input->buffer + bufferSize;
+	input->numChannels = numChannels;
+
+	input->the = the;
+	input->object = xsThis;
+	xsRemember(input->object);
+	input->onReadable = builtinGetCallback(the, xsID_onReadable);	
+	builtinInitializeTarget(the);
+
+	input->sampleRate = sampleRate;
+	input->bitsPerSample = bitsPerSample;
+
+#if MODDEF_AUDIOIN_I2S_PDM
+	gPDMAudioInBusy = 1;
+#endif
+
+	input->dmaReadBytes = AUDIO_IN_DMA_FRAMES * ((1 == numChannels) ? 4 : bytesPerFrame);
+
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+	{
+		esp_err_t err = audioInOpenStdChannel(input);
+		if (ESP_OK != err) {
+			xsForget(input->object);
+			c_free(input);
+			xsmcSetHostData(xsThis, C_NULL);
+			xsUnknownError("I2S input setup failed");
+		}
+	}
+#endif
+
+	input->mutex = xSemaphoreCreateMutex();
+	if (!input->mutex) {
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+		audioInCloseChannel(input);
+#endif
+		xsForget(input->object);
+		c_free(input);
+		xsmcSetHostData(xsThis, C_NULL);
+		xsUnknownError("no memory for AudioIn mutex");
+	}
+	if (pdPASS != xTaskCreate(audioInLoop, "audioInput", 4096 + 1024, input, 10, &input->task)) {
+#if !MODDEF_AUDIOIN_I2S_ADC && !MODDEF_AUDIOIN_I2S_PDM
+		audioInCloseChannel(input);
+#endif
+		vSemaphoreDelete(input->mutex);
+		xsForget(input->object);
+		c_free(input);
+		xsmcSetHostData(xsThis, C_NULL);
+		xsUnknownError("AudioIn task create failed");
+	}
+}
+
+void xs_audioin_destructor(void *it)
+{
+	if (it) {
+		AudioInput input = it;
+		input->state = kStateClosing;
+		if (input->task) {
+			xTaskNotify(input->task, kStateClosing, eSetValueWithOverwrite);
+			while (kStateClosing == input->state)
+				modDelayMilliseconds(1);
+
+			vSemaphoreDelete(input->mutex);
+		}
+
+		if (input->pendingCallback) {
+			input->state = kStateTerminated;
+			return;
+		}
+
+		c_free(input);
+	}
+}
+
+void xs_audioin_close(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostData(xsThis);
+	if (input && xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks)) {
+		xsmcSetHostData(xsThis, C_NULL);
+		xsmcSetHostDestructor(xsThis, C_NULL);
+		xsForget(input->object);
+		xs_audioin_destructor(input);
+	}
+}
+
+void xs_audioin_mark(xsMachine* the, void* it, xsMarkRoot markRoot)
+{
+	AudioInput input = it;
+	if (input->onReadable)
+		(*markRoot)(the, input->onReadable);
+}
+
+void xs_audioin_level(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	xsUnsignedValue requested;
+	uint8_t* buffer;
+	int16_t* samples;
+	int32_t	i;
+	double ave = 0.0;
+
+	xsResult = xsArg(0);
+	xsmcGetBufferReadable(xsResult, (void **)&buffer, &requested);
+
+	requested /= 2;
+	samples = (int16_t*)buffer;
+	
+	for (i=0; i<requested; i++) {
+		int16_t sample = samples[i];
+		if (sample < 0) sample = -sample;
+		ave += sample;
+	}
+
+	int result = c_round(ave / requested);
+
+	xsmcSetInteger(xsResult, result);
+}
+
+void xs_audioin_read(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	esp_err_t err;
+	xsUnsignedValue available, requested;
+	xsBooleanValue allocate = 1;
+	uint8_t* buffer;
+
+	xSemaphoreTake(input->mutex, portMAX_DELAY);
+	available = amtReadable(input);
+	xSemaphoreGive(input->mutex);
+
+	if (input->numChannels == 1)
+		available /= 2;					// strip left channel
+
+	if (0 == available)
+		return;		// read returns undefined if nothing available
+
+	if (0 == xsmcArgc)
+		requested = available;
+	else if (xsReferenceType == xsmcTypeOf(xsArg(0))) {
+		xsResult = xsArg(0);
+		xsmcGetBufferWritable(xsResult, (void **)&buffer, &requested);
+		xsmcSetInteger(xsResult, requested);
+		allocate = 0;
+	}
+	else
+		requested = xsmcToInteger(xsArg(0));
+
+	if ((requested <= 0) || (requested > available))
+		xsUnknownError("invalid size");
+
+	if (allocate)
+		buffer = xsmcSetArrayBuffer(xsResult, C_NULL, requested);
+
+	countBytes(AudioInConsumed, requested);
+
+	double bias = 0.0;
+	int16_t	*samples = (int16_t	*)buffer;
+
+	xsUnsignedValue remaining = requested;
+	xSemaphoreTake(input->mutex, portMAX_DELAY);
+	if (input->recPos < input->playPos) {
+		available = input->endPos - input->playPos;
+		while ((remaining > 0) && (input->playPos < input->endPos)) {
+			if (input->numChannels == 2) {
+				*samples = (*(uint16_t*)input->playPos);
+				bias += *samples++;
+				input->playPos += 2;
+				*samples = (*(uint16_t*)input->playPos);
+				bias += *samples++;
+				input->playPos += 2;
+				remaining -= 4;
+			}
+			else {
+				*samples = (*(uint32_t*)input->playPos) & 0xffff;		// take the bottom 16 bits
+				bias += *samples++;
+				input->playPos += 4;
+				remaining -= 2;
+			}
+		}
+		if (input->playPos == input->endPos)
+			input->playPos = input->buffer;
+	}
+	if (input->recPos != input->playPos) {
+		while (input->recPos > input->playPos) {
+			if (0 == remaining)
+				break;
+			if (input->numChannels == 2) {
+				*samples = *((uint16_t*)input->playPos);
+				bias += *samples++;
+				input->playPos += 2;
+				*samples = *((uint16_t*)input->playPos);
+				bias += *samples++;
+				input->playPos += 2;
+				remaining -= 4;
+			}
+			else {
+				*samples = (*(uint32_t*)input->playPos) & 0xffff;		// take the bottom 16 bits
+				bias += *samples++;
+				input->playPos += 4;
+				remaining -= 2;
+			}
+		}
+	}
+	xSemaphoreGive(input->mutex);
+
+	int32_t i;
+	samples = (uint16_t *)buffer;
+	requested /= 2;		// samples
+	bias /= requested;
+
+#if (1 != MODDEF_AUDIOIN_I2S_MULTIPLIER) || MODDEF_AUDIOIN_I2S_BIAS
+	for (i=0; i<requested; i++) {
+#if MODDEF_AUDIOIN_I2S_BIAS
+		int32_t sample = samples[i] - bias;
+#else
+		int32_t sample = samples[i];
+#endif
+		sample *= MODDEF_AUDIOIN_I2S_MULTIPLIER;
+		if (sample > 32767) 		// clip
+			sample = 32767;
+		else if (sample < -32768)
+			sample = -32768;
+		samples[i] = (int16_t)sample;
+	}
+#endif
+}
+
+void deliverCallbacks(void *the, void *refcon, uint8_t *message, uint16_t messageLength)
+{
+	AudioInput input = refcon;
+	uint32_t bytes_read;
+
+	if (kStateTerminated == input->state) {
+		c_free(input);
+		return;
+	} 
+
+	xsBeginHost(input->the);
+
+	bytes_read = amtReadable(input);
+	if (input->numChannels == 1)		// only lower 16 bits
+		bytes_read /= 2;
+
+	if (0 != bytes_read) {
+		xsResult = xsAccess(input->object);
+		xsCallFunction1(xsReference(input->onReadable), xsResult, xsInteger(bytes_read));
+	}
+
+	input->pendingCallback = 0;
+
+	xsEndHost(input->the);
+}
+
+void audioInLoop(void *pvParameter)
+{
+	AudioInput input = pvParameter;
+	uint8_t stopped = true, enabled = false;
+
+	if (input->handle)
+		goto ready;
+
+// ### HW CONFIGURATION
+#if MODDEF_AUDIOIN_I2S_ADC
+#error untested
+	adc_continuous_handle_t adcHandle;
+	adc_continuous_handle_cfg_t adc_config = {
+		.max_store_buf_size = 1024,
+		.conv_frame_size = kADCSampleLength,
+	};
+	ESP_ERROR_CHECK(adc_continuous_new_handle(&adc_config, &adcHandle));
+
+	adc_continuous_config_t dig_cfg = {
+		.sample_freq_hz = input->sampleRate,
+		.conv_mode = ADC_CONF_SINGLE_UNIT_1,
+		.format = ADC_DIGI_OUTPUT_FORMAT_TYPE1,
+	};
+
+	adc_digi_pattern_config_t adc_pattern[1] = {0};
+	adc_pattern[0].atten = ADC_ATTEN_DB_11;
+	adc_pattern[0].channel = ADC_CHANNEL_6;		//@@ config
+	adc_pattern[0].unit = ADC_UNIT_1;			//@@ config
+	adc_pattern[0].bit_width = ADC_BITWIDTH_12;
+	dig_cfg.pattern_num = 1;
+	dig_cfg.adc_pattern = adc_pattern;
+	ESP_ERROR_CHECK(adc_continuous_config(adcHandle, &dig_cfg));
+
+	ESP_ERROR_CHECK(adc_continuous_start(adcHandle));
+	input->handle = adcHandle;
+#else
+	esp_err_t err;
+
+	i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(MODDEF_AUDIOIN_I2S_NUM, I2S_ROLE_MASTER);
+	err = i2s_new_channel(&chan_cfg, C_NULL, &input->handle);
+	if (err) modLog("i2s_new_channel failed");
+
+#if MODDEF_AUDIOIN_I2S_PDM
+	i2s_pdm_rx_config_t pdm_rx_cfg = {
+		.clk_cfg = I2S_PDM_RX_CLK_DEFAULT_CONFIG(input->sampleRate),
+		.slot_cfg = I2S_PDM_RX_SLOT_DEFAULT_CONFIG(
+				input->bitsPerSample == 8 ? I2S_DATA_BIT_WIDTH_8BIT : I2S_DATA_BIT_WIDTH_16BIT,
+				I2S_SLOT_MODE_MONO),
+		.gpio_cfg = {
+			.clk = MODDEF_AUDIOIN_I2S_LR_PIN,
+			.din = MODDEF_AUDIOIN_I2S_DATAIN,
+			.invert_flags = {
+				.clk_inv = false,
+			}
+		}
+	};
+
+	pdm_rx_cfg.slot_cfg.slot_mask = MODDEF_AUDIOIN_I2S_SLOT;
+	pdm_rx_cfg.clk_cfg.dn_sample_mode = I2S_PDM_DSR_16S;
+
+	err = i2s_channel_init_pdm_rx_mode(input->handle, &pdm_rx_cfg);
+	if (err) {
+		i2s_del_channel(input->handle);
+		input->handle = C_NULL;
+		modLog("i2s_channel_init_pdm_rx_mode failed");
+	}
+#else
+	i2s_std_config_t rx_std_cfg = {
+		.clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(input->sampleRate),
+#if MODDEF_AUDIOIN_I2S_FORMAT_I2S
+		.slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT,
+			(2 == MODDEF_AUDIOIN_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO),
+#else
+		.slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT,
+			(2 == MODDEF_AUDIOIN_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO),
+#endif
+		.gpio_cfg = {
+			.mclk = MODDEF_AUDIOIN_I2S_MCK_PIN,
+			.bclk = MODDEF_AUDIOIN_I2S_BCK_PIN,
+			.ws = MODDEF_AUDIOIN_I2S_LR_PIN,
+			.dout = I2S_GPIO_UNUSED,
+			.din = MODDEF_AUDIOIN_I2S_DATAIN,
+			.invert_flags = {
+				.mclk_inv = false,
+				.bclk_inv = false,
+				.ws_inv = false,
+			}
+		}
+	};
+	rx_std_cfg.slot_cfg.slot_mask = (2 == MODDEF_AUDIOIN_NUMCHANNELS)
+		? I2S_STD_SLOT_BOTH
+		: MODDEF_AUDIOIN_I2S_SLOT; 		//@@
+
+	err = i2s_channel_init_std_mode(input->handle, &rx_std_cfg);
+	if (err) {
+		if (ESP_OK == i2s_del_channel(input->handle))
+			input->handle = C_NULL;
+		modLog("i2s_channel_init failed");
+	}
+#endif
+
+	/* Leave the RX channel in READY until start(). Enabling here drives BCLK/WS
+	 * while ChatAudioIO still considers the microphone idle. */
+	enabled = false;
+#endif
+
+ready:
+	if (C_NULL == input->handle)
+		goto done;
+
+	while (true) {
+		size_t bytes_read = 0;
+
+		if (kStateRecording != input->state) {
+			uint32_t newState;
+
+			if (!stopped) {
+#if MODDEF_AUDIOIN_I2S_ADC
+				adc_continuous_stop(input->handle);
+#else
+				if (enabled)
+					i2s_channel_disable(input->handle);
+				enabled = false;
+#endif
+				stopped = true;
+
+				input->playPos = input->recPos = input->buffer;
+			}
+
+			if ((kStateClosing == input->state) || (kStateTerminated == input->state))
+				break;
+
+			xTaskNotifyWait(0, 0, &newState, portMAX_DELAY);
+			continue;
+		}
+
+		if (stopped) {
+#if MODDEF_AUDIOIN_I2S_ADC
+			adc_continuous_enable(input->handle);
+#else
+			if (!enabled)
+				i2s_channel_enable(input->handle);
+			enabled = true;
+#endif
+
+			stopped = false;
+		}
+
+#if MODDEF_AUDIOIN_I2S_ADC
+#error untested
+		uint32_t use = sizeof(input);
+		uint32_t needed = requested * sizeof(adc_digi_output_data_t);
+		if (use > needed) use = needed;
+		uint32_t used;
+
+		err = adc_continuous_read(input->handle, input, use, &used, 17);
+		if (err) break;
+
+		used /= sizeof(adc_digi_output_data_t);
+		requested -= used;
+
+        adc_digi_output_data_t *in = (adc_digi_output_data_t *)input;
+#if 8 == MODDEF_AUDIOIN_BITSPERSAMPLE
+		uint8_t *out = (uint8_t *)buffer;
+		while (used--) {
+			*out++ in->type1.data >> 4;
+			in++;
+		}
+		samples = (void *)out;
+#else // 16 == MODDEF_AUDIOIN_BITSPERSAMPLE
+		uint16_t *out = (uint16_t *)buffer;
+		while (used--) {
+			*out++ = (in->type1.data - 2048) * 8;
+			in++;
+		}
+		samples = (void *)out;
+#endif
+    
+#elif MODDEF_AUDIOIN_I2S_PDM && (8 == MODDEF_AUDIOIN_BITSPERSAMPLE)
+   		int8_t *out = buffer;
+		int i;
+		while (sampleCount) {
+			const int tmpCount = 512;
+			int16_t tmp[tmpCount];
+			int use = sampleCount;
+			if (use > tmpCount)
+				use = tmpCount;
+			err = i2s_channel_read(input->handle, (char *)tmp, use << 1, &bytes_read, AUDIO_IN_TIMEOUT);
+			if (err) break;
+
+			for (i=0; i < use; i++)
+				*out++ = (tmp[i] >> 8) ^ 0x80;
+			sampleCount -= use;
+		}
+#else
+		xSemaphoreTake(input->mutex, portMAX_DELAY);
+		uint32_t	amt;
+		if (input->playPos > input->recPos)
+			amt = input->playPos - input->recPos;
+		else
+			amt = input->endPos - input->recPos;
+		if (amt == 0) {
+			amt = input->playPos - input->buffer;
+			input->recPos = input->buffer;
+		}
+		xSemaphoreGive(input->mutex);
+		if (input->dmaReadBytes && (amt > input->dmaReadBytes))
+			amt = input->dmaReadBytes;
+		amt = (amt > MAX_INPUT_BLOCK) ? MAX_INPUT_BLOCK : amt;
+		if (input->dmaReadBytes)
+			amt -= (amt % input->dmaReadBytes);
+		if (amt > 0) {
+			err = i2s_channel_read(input->handle, input->recPos, amt, &bytes_read, AUDIO_IN_TIMEOUT);
+			if (ESP_ERR_TIMEOUT == err)
+				continue;
+			if ((ESP_OK != err) || (0 == bytes_read) ||
+				(input->dmaReadBytes && (bytes_read % input->dmaReadBytes)))
+				continue;
+			xSemaphoreTake(input->mutex, portMAX_DELAY);
+			input->recPos += bytes_read;
+			xSemaphoreGive(input->mutex);
+		}
+#endif
+
+		if (input->onReadable && (bytes_read > 0)) {
+			if (!input->pendingCallback) {
+				input->pendingCallback = 1;
+				modMessagePostToMachine(input->the, C_NULL, 0, deliverCallbacks, input);
+			}
+		}
+
+		countBytes(AudioInRead, bytes_read);
+	}
+
+	// ## HW shutdown
+	if (input->handle) {
+#if MODDEF_AUDIOIN_I2S_ADC
+		adc_continuous_deinit(input->handle);
+		input->handle = C_NULL;
+#else
+		if (enabled)
+			i2s_channel_disable(input->handle);
+		if (ESP_OK == i2s_del_channel(input->handle))
+			input->handle = C_NULL;
+#endif
+	}
+
+done:
+#if MODDEF_AUDIOIN_I2S_PDM
+	gPDMAudioInBusy = 0;
+#endif
+
+	input->state = kStateTerminated;
+	input->task = C_NULL;
+
+	vTaskDelete(C_NULL);
+}
+
+void xs_audioin_start(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	input->state = kStateRecording;
+	xTaskNotify(input->task, kStateRecording, eSetValueWithOverwrite);
+}
+
+void xs_audioin_stop(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	input->state = kStateIdle;
+	xTaskNotify(input->task, kStateIdle, eSetValueWithOverwrite);
+}
+
+void xs_audioin_get_format(xsMachine *the)
+{
+	xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	builtinGetFormat(the, kIOFormatBuffer);
+}
+
+void xs_audioin_set_format(xsMachine *the)
+{
+	xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	uint8_t format = builtinSetFormat(the);
+	if (kIOFormatBuffer != format)
+		xsRangeError("invalid format");
+}
+
+void xs_audioin_get_bitsPerSample(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	xsmcSetInteger(xsResult, input->bitsPerSample);
+}
+
+void xs_audioin_get_channels(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	xsmcSetInteger(xsResult, input->numChannels);
+}
+
+void xs_audioin_get_sampleRate(xsMachine *the)
+{
+	AudioInput input = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioInHooks);
+	xsmcSetInteger(xsResult, input->sampleRate);
+}

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioin/audioin.js
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioin/audioin.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024-2026  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class AudioIn extends Native('xs_audioin_destructor') {
+  constructor(dictionary) {
+    super()
+    native('xs_audioin_constructor').call(this, dictionary)
+  }
+  close() {
+    return native('xs_audioin_close').call(this)
+  }
+  read(samples) {
+    return native('xs_audioin_read').call(this, samples)
+  }
+  level(samples) {
+    return native('xs_audioin_level').call(this, samples)
+  }
+  start() {
+    return native('xs_audioin_start').call(this)
+  }
+  stop() {
+    return native('xs_audioin_stop').call(this)
+  }
+
+  get format() {
+    return native('xs_audioin_get_format').call(this)
+  }
+  set format(it) {
+    native('xs_audioin_set_format').call(this, it)
+  }
+
+  get bitsPerSample() {
+    return native('xs_audioin_get_bitsPerSample').call(this)
+  }
+  get channels() {
+    return native('xs_audioin_get_channels').call(this)
+  }
+  get sampleRate() {
+    return native('xs_audioin_get_sampleRate').call(this)
+  }
+  get audioType() {
+    return 'LPCM'
+  }
+
+  static {
+    this.prototype[Symbol.dispose] = this.prototype.close
+  }
+}
+
+export default AudioIn

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32.c
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32.c
@@ -1,0 +1,809 @@
+/*
+ * Stack-chan overlay of Moddable modules/io/audioout/esp32/audioout-esp32.c.
+ * Uses MODDEF_AUDIOOUT_I2S_NUM and IDF Philips/MSB slot macros.
+ *
+ * Copyright (c) 2024-2026 Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *  
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.  
+ *
+ */
+
+#include "xsmc.h"
+#include "mc.xs.h"
+#include "mc.defines.h"
+
+#include "builtinCommon.h"
+
+#include "driver/i2s_pdm.h"
+#include "driver/i2s_std.h"
+#include "freertos/task.h"
+
+#ifdef MODDEF_AUDIOOUT_AMPLIFIER_POWER
+	#include "modGPIO.h"
+#endif
+
+#ifndef MODDEF_AUDIOOUT_I2S_NUM
+	#define MODDEF_AUDIOOUT_I2S_NUM I2S_NUM_AUTO
+#endif
+
+#ifndef MODDEF_AUDIOOUT_I2S_SLOT
+	#define MODDEF_AUDIOOUT_I2S_SLOT I2S_STD_SLOT_RIGHT
+#endif
+
+#ifndef MODDEF_AUDIOOUT_I2S_MCK_PIN
+	#define MODDEF_AUDIOOUT_I2S_MCK_PIN I2S_GPIO_UNUSED
+#endif
+
+#ifndef MODDEF_AUDIOOUT_I2S_FORMAT_I2S
+	#define MODDEF_AUDIOOUT_I2S_FORMAT_I2S 0
+#endif
+
+#include "xsHost.h"
+
+#ifdef MODDEF_AUDIOOUT_I2S_PDM_PIN
+	uint8_t gPDMAudioOutBusy = 0;
+	uint8_t gPDMAudioInBusy __attribute__((weak)) = 0;
+#endif
+
+typedef struct AudioOutElementRecord AudioOutElementRecord;
+typedef struct AudioOutElementRecord *AudioOutElement;
+
+struct AudioOutElementRecord {
+	AudioOutElement		next;
+
+	xsSlot				*completion;
+	xsSlot				*buffer;
+	void				*data;		// NULL if relocatable
+	
+	uint32_t			position;
+	uint32_t			bytesAvailable;
+	
+	esp_err_t			err;
+};
+
+typedef struct AudioOutRecord AudioOutRecord;
+typedef struct AudioOutRecord *AudioOut;
+
+struct AudioOutRecord {
+	xsSlot				obj;
+	uint32_t			total_dma_buf_size;
+	uint32_t			dma_buf_size;
+	uint32_t			bytesWritable;
+	uint8_t				useCount;
+	uint8_t				started;
+	uint8_t				callbackPending;
+
+	uint16_t			sampleRate;
+	uint8_t				numChannels;
+	uint8_t				bitsPerSample;
+
+	uint8_t				*stagingBuffer;
+	uint32_t			stagingOffset;
+
+	i2s_chan_handle_t	tx_handle;
+
+	xsMachine			*the;
+	xsSlot				*onWritable;
+
+	double				volumeDouble;
+	int16_t				volumeFixed;
+	
+	AudioOutElement		elements;
+	volatile TaskHandle_t		task;
+
+#ifdef MODDEF_AUDIOOUT_AMPLIFIER_POWER
+	modGPIOConfigurationRecord	amplifierPower;
+	int						bytesInFlight;
+#endif
+};
+
+static bool playedBuffer(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx);
+static esp_err_t doWrite(AudioOut audioOut, void *buffer, xsUnsignedValue bytes);
+static void audiooutDeliver(void *theIn, void *refcon, uint8_t *message, uint16_t messageLength);
+static void xs_audioout_mark_(xsMachine* the, void* it, xsMarkRoot markRoot);
+static void audioOutLoop(void *pvParameter);
+
+static const xsHostHooks ICACHE_RODATA_ATTR xsAudioOutHooks = {
+	xs_audioout_destructor_,
+	xs_audioout_mark_,
+	C_NULL
+};
+
+static void audioOutRelease(AudioOut audioOut)
+{
+	if (audioOut->task) {
+		xTaskNotify(audioOut->task, 2, eSetValueWithOverwrite);	// end task
+		while (audioOut->task)
+			modDelayMilliseconds(1);
+	}
+
+	if (audioOut->tx_handle) {
+		i2s_channel_disable(audioOut->tx_handle);
+		i2s_del_channel(audioOut->tx_handle);
+		audioOut->tx_handle = NULL;
+	}
+#ifdef MODDEF_AUDIOOUT_I2S_PDM_PIN
+	gPDMAudioOutBusy = 0;
+#endif
+
+	while (audioOut->elements) {
+		AudioOutElement element = audioOut->elements, next = element->next;
+		c_free(element);
+		audioOut->elements = next;
+	}
+
+	if (audioOut->stagingBuffer) {
+		c_free(audioOut->stagingBuffer);
+		audioOut->stagingBuffer = NULL;
+	}
+}
+
+void xs_audioout_destructor_(void *data)
+{
+	AudioOut audioOut = data;
+	if (!audioOut) return;
+	
+	audioOutRelease(audioOut);
+	c_free(audioOut);
+}
+
+void xs_audioout_constructor_(xsMachine *the)
+{
+	AudioOut audioOut;
+	xsSlot *onWritable;
+	esp_err_t err;
+	int sampleRate = 0;
+	int numChannels = 0;
+	int bitsPerSample = 0;
+
+	xsmcVars(1);
+
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_sampleRate))
+		sampleRate = xsmcToInteger(xsVar(0));
+#ifdef MODDEF_AUDIOOUT_SAMPLERATE
+	else
+		sampleRate = MODDEF_AUDIOOUT_SAMPLERATE;
+#endif
+	if ((sampleRate < 8000) || (sampleRate > 48000))
+		xsRangeError("invalid sample rate");
+
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_channels))
+		numChannels = xsmcToInteger(xsVar(0));
+#ifdef MODDEF_AUDIOOUT_NUMCHANNELS
+	else
+		numChannels = MODDEF_AUDIOOUT_NUMCHANNELS;
+#endif
+	if ((1 != numChannels) && (2 != numChannels))
+		xsRangeError("bad numChannels");
+
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_bitsPerSample))
+		bitsPerSample = xsmcToInteger(xsVar(0));
+#ifdef MODDEF_AUDIOOUT_BITSPERSAMPLE
+	else
+		bitsPerSample = MODDEF_AUDIOOUT_BITSPERSAMPLE;
+#endif
+	if ((8 != bitsPerSample) && (16 != bitsPerSample))
+		xsRangeError("bad bitsPerSample");
+
+	if (xsmcGet(xsVar(0), xsArg(0), xsID_audioType)) {
+		char *type = xsmcToString(xsVar(0));
+		if (c_strcmp(type, "LPCM"))
+			xsRangeError("invalid audioType");
+	}
+
+	onWritable = builtinGetCallback(the, xsID_onWritable);
+
+	builtinInitializeTarget(the);
+
+	if (kIOFormatBuffer != builtinInitializeFormat(the, kIOFormatBuffer))
+		xsRangeError("invalid format");
+
+	audioOut = c_calloc(1, sizeof(AudioOutRecord));
+	if (!audioOut)
+		xsRangeError("no memory");
+
+	xsmcSetHostData(xsThis, audioOut);
+
+	audioOut->the = the;
+	audioOut->obj = xsThis;
+
+	audioOut->useCount = 1;
+
+	audioOut->sampleRate = (uint16_t)sampleRate;
+	audioOut->numChannels = (uint8_t)numChannels;
+	audioOut->bitsPerSample = (uint8_t)bitsPerSample;
+
+	audioOut->onWritable = onWritable;
+	
+	audioOut->volumeDouble = 1.0;
+	audioOut->volumeFixed = 256;
+
+	xsSetHostHooks(xsThis, (xsHostHooks *)&xsAudioOutHooks);
+	xsRemember(audioOut->obj);
+
+    i2s_chan_config_t tx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(MODDEF_AUDIOOUT_I2S_NUM, I2S_ROLE_MASTER);
+    tx_chan_cfg.auto_clear = true;
+
+	// number of DMA buffers and their size in samples (default is 6 and 240)
+#ifndef I2S_DMA_BUFFER_MAX_SIZE
+	#define I2S_DMA_BUFFER_MAX_SIZE     (4092)
+#endif
+
+	tx_chan_cfg.dma_desc_num = 6;
+	tx_chan_cfg.dma_frame_num = I2S_DMA_BUFFER_MAX_SIZE / 2;
+
+#ifdef MODDEF_AUDIOOUT_I2S_PDM_PIN
+	if (gPDMAudioOutBusy)
+		xsUnknownError("already in use");
+
+	if (gPDMAudioInBusy)
+		xsUnknownError("pdm already in use by audioin");
+
+	i2s_pdm_tx_config_t tx_cfg = {
+		.clk_cfg = I2S_PDM_TX_CLK_DAC_DEFAULT_CONFIG(audioOut->sampleRate),
+		.slot_cfg = I2S_PDM_TX_SLOT_DAC_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
+		.gpio_cfg = {
+			.clk = -1,
+			.dout = MODDEF_AUDIOOUT_I2S_PDM_PIN,
+			.invert_flags = {
+				.clk_inv = false,
+			},
+		},
+	};
+#elif MODDEF_AUDIOOUT_I2S_BCK_PIN
+	i2s_std_config_t i2s_config = {
+		.gpio_cfg = {
+			.mclk = MODDEF_AUDIOOUT_I2S_MCK_PIN,
+			.bclk = MODDEF_AUDIOOUT_I2S_BCK_PIN,
+			.ws = MODDEF_AUDIOOUT_I2S_LR_PIN,
+			.dout = MODDEF_AUDIOOUT_I2S_DATAOUT_PIN,
+			.din = I2S_GPIO_UNUSED,
+			.invert_flags = {
+				.mclk_inv = false,
+				.bclk_inv = false,
+				.ws_inv = false,
+			},
+		},
+	};
+
+	// I2S_STD_CLK_DEFAULT_CONFIG(sampleRate)  (i2s_std.h)
+	i2s_config.clk_cfg.sample_rate_hz = audioOut->sampleRate;
+	i2s_config.clk_cfg.clk_src = I2S_CLK_SRC_DEFAULT;
+	i2s_config.clk_cfg.mclk_multiple = I2S_MCLK_MULTIPLE_256;
+
+#if MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE == 32
+	i2s_config.slot_cfg.data_bit_width = I2S_DATA_BIT_WIDTH_16BIT;
+	i2s_config.slot_cfg.ws_width = I2S_DATA_BIT_WIDTH_32BIT;
+	i2s_config.slot_cfg.slot_bit_width = I2S_SLOT_BIT_WIDTH_AUTO;
+	i2s_config.slot_cfg.ws_pol = false;
+#if SOC_I2S_HW_VERSION_1
+	i2s_config.slot_cfg.msb_right = false;
+#else
+	i2s_config.slot_cfg.left_align = false;
+	i2s_config.slot_cfg.big_endian = false;
+	i2s_config.slot_cfg.bit_order_lsb = false;
+#endif
+#if MODDEF_AUDIOOUT_I2S_FORMAT_I2S
+	i2s_config.slot_cfg.bit_shift = true;
+#else
+	i2s_config.slot_cfg.bit_shift = false;
+#endif
+#if MODDEF_AUDIOOUT_NUMCHANNELS == 2
+	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_STEREO;
+	i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+#else
+	i2s_config.slot_cfg.slot_mode = I2S_SLOT_MODE_MONO;
+	i2s_config.slot_cfg.slot_mask = MODDEF_AUDIOOUT_I2S_SLOT;
+#endif
+#else
+	{
+		const i2s_data_bit_width_t width =
+#if MODDEF_AUDIOOUT_I2S_BITSPERSAMPLE == 16
+			I2S_DATA_BIT_WIDTH_16BIT;
+#else
+			I2S_DATA_BIT_WIDTH_8BIT;
+#endif
+		const i2s_slot_mode_t mode =
+			(2 == MODDEF_AUDIOOUT_NUMCHANNELS) ? I2S_SLOT_MODE_STEREO : I2S_SLOT_MODE_MONO;
+#if MODDEF_AUDIOOUT_I2S_FORMAT_I2S
+		i2s_config.slot_cfg = (i2s_std_slot_config_t)I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(width, mode);
+#else
+		i2s_config.slot_cfg = (i2s_std_slot_config_t)I2S_STD_MSB_SLOT_DEFAULT_CONFIG(width, mode);
+#endif
+#if MODDEF_AUDIOOUT_NUMCHANNELS == 2
+		i2s_config.slot_cfg.slot_mask = I2S_STD_SLOT_BOTH;
+#else
+		i2s_config.slot_cfg.slot_mask = MODDEF_AUDIOOUT_I2S_SLOT;
+#endif
+	}
+#endif
+
+
+#elif MODDEF_AUDIOOUT_I2S_DAC
+	#error DAC audio unimplemented
+#else
+	#error unknown audio configuration
+#endif
+
+	err = i2s_new_channel(&tx_chan_cfg, &audioOut->tx_handle, C_NULL);
+	if (ESP_OK != err)
+		xsUnknownError("new channel failed %d", (int)err);
+#if MODDEF_AUDIOOUT_I2S_PDM_PIN
+	err = i2s_channel_init_pdm_tx_mode(audioOut->tx_handle, &tx_cfg);
+	if (ESP_OK != err)
+		xsUnknownError("init PDM failed %d", (int)err);
+	gPDMAudioOutBusy = 1;
+#elif MODDEF_AUDIOOUT_I2S_BCK_PIN
+	err = i2s_channel_init_std_mode(audioOut->tx_handle, &i2s_config);
+	if (ESP_OK != err)
+		xsUnknownError("init I2S failed %d", (int)err);
+	i2s_channel_reconfig_std_slot(audioOut->tx_handle, &i2s_config.slot_cfg);
+	i2s_channel_reconfig_std_clock(audioOut->tx_handle, &i2s_config.clk_cfg);
+#elif MODDEF_AUDIOOUT_I2S_DAC
+#else
+#endif
+
+	i2s_event_callbacks_t cbs = {
+		.on_recv = C_NULL,
+		.on_recv_q_ovf = C_NULL,
+		.on_sent = playedBuffer,
+		.on_send_q_ovf = C_NULL,
+	};
+	i2s_channel_register_event_callback(audioOut->tx_handle, &cbs, audioOut);
+
+	audioOut->dma_buf_size = tx_chan_cfg.dma_frame_num * 2;			//@@ wrong for stereo etc
+	audioOut->total_dma_buf_size = audioOut->dma_buf_size * (tx_chan_cfg.dma_desc_num - 1);
+	audioOut->bytesWritable = audioOut->total_dma_buf_size;
+	audioOut->stagingBuffer = c_malloc(audioOut->dma_buf_size);
+	if (!audioOut->stagingBuffer) {
+		audioOutRelease(audioOut);
+		xsForget(audioOut->obj);
+		xsRangeError("no memory");
+	}
+
+#if ESP32 && defined(MODDEF_AUDIOOUT_AMPLIFIER_POWER)
+	modGPIOInit(&audioOut->amplifierPower, C_NULL, MODDEF_AUDIOOUT_AMPLIFIER_POWER, kModGPIOOutput);
+	modGPIOWrite(&audioOut->amplifierPower, 1);		//@@ always on
+#endif
+
+	if (!audioOut->callbackPending && audioOut->onWritable) {
+		audioOut->callbackPending = true;
+		__atomic_add_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+		modMessagePostToMachine(audioOut->the, C_NULL, 0, audiooutDeliver, audioOut);
+	}
+}
+ 
+void xs_audioout_close_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostData(xsThis);
+	if (audioOut && xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks)) {
+		xsForget(audioOut->obj);
+		
+#if !mxUseGCCAtomics
+		uint8_t useCount = --audioOut->useCount;
+#else
+		uint8_t useCount = __atomic_sub_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+#endif
+		audioOutRelease(audioOut);
+		if (0 == audioOut->useCount)
+			xs_audioout_destructor_(audioOut);
+		xsmcSetHostData(xsThis, C_NULL);
+		xsmcSetHostDestructor(xsThis, C_NULL);
+	}
+}
+ 
+void xs_audioout_start_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	esp_err_t err;
+
+	if (audioOut->started)
+		return;
+
+	// prime IDF buffers
+	size_t ignore = 0;
+	i2s_channel_preload_data(audioOut->tx_handle, &ignore, 0, &ignore);
+
+	err = i2s_channel_enable(audioOut->tx_handle);
+	if (ESP_OK != err)
+		xsUnknownError("can't enable %d", (int)err);
+
+	audioOut->started = true;
+	audioOut->bytesWritable = audioOut->total_dma_buf_size;
+
+	if (!audioOut->callbackPending /* && audioOut->onWritable */) {
+		audioOut->callbackPending = true;
+		__atomic_add_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+		modMessagePostToMachine(audioOut->the, C_NULL, 0, audiooutDeliver, audioOut);
+	}
+}
+ 
+void xs_audioout_stop_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+
+	if (!audioOut->started)
+		return;
+
+	i2s_channel_disable(audioOut->tx_handle);
+	audioOut->started = false;
+	audioOut->bytesWritable = audioOut->total_dma_buf_size;
+	audioOut->stagingOffset = 0;
+}
+ 
+void xs_audioout_writeSync_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	void *buffer;
+	xsUnsignedValue requested;
+	esp_err_t err;
+
+	xsmcGetBufferReadable(xsArg(0), &buffer, &requested);
+
+	if (requested > (audioOut->bytesWritable - audioOut->stagingOffset))
+		xsUnknownError("insufficient space");
+
+	if (requested & 1)							//@@ broken for stereo & 8 bit
+		xsUnknownError("full samples only");
+
+	err = doWrite(audioOut, buffer, requested);
+	if (err)
+		xsUnknownError("write failed %d", (int)err);
+}
+ 
+ void xs_audioout_writeAsync_(xsMachine *the)
+ {
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	AudioOutElement element;
+	xsSlot *buffer, *completion = C_NULL;
+	void *data;
+	xsUnsignedValue bytesAvailable;
+
+	if (xsBufferRelocatable == xsmcGetBufferReadable(xsArg(0), &data, &bytesAvailable))
+		data = C_NULL;
+	else if (!audioOut->task) {
+		xTaskCreate(audioOutLoop, "audioOut", 1536 + XT_STACK_EXTRA_CLIB, audioOut, 10, (TaskHandle_t *)&audioOut->task);
+		if (!audioOut->task)
+			xsUnknownError("can't create task");
+	}
+	
+	buffer = xsmcToReference(xsArg(0));
+	if (xsmcArgc > 1)
+		completion = xsmcToReference(xsArg(1));
+
+	element = c_calloc(1, sizeof(AudioOutElementRecord));
+	if (!element)
+		xsUnknownError("no memory");
+	
+	element->completion = completion;
+	element->buffer = buffer;
+	element->data = data;
+	element->bytesAvailable = bytesAvailable;
+
+//@@ lock around queue manipulation
+
+	if (audioOut->elements) {
+		AudioOutElement walker = audioOut->elements;
+		while (walker->next)
+			walker = walker->next;
+		walker->next = element;
+	}
+	else
+		audioOut->elements = element;
+
+//@@ write to start playing if there's space?
+}
+
+void xs_audioout_get_format_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	builtinGetFormat(the, kIOFormatBuffer);
+}
+ 
+void xs_audioout_set_format_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	if (kIOFormatBuffer != builtinSetFormat(the))
+		xsRangeError("invalid format");
+}
+ 
+void xs_audioout_get_bitsPerSample_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	xsmcSetInteger(xsResult, audioOut->bitsPerSample);
+}
+ 
+void xs_audioout_get_numChannels_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	xsmcSetInteger(xsResult, audioOut->numChannels);
+}
+ 
+void xs_audioout_get_sampleRate_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	xsmcSetInteger(xsResult, audioOut->sampleRate);
+}
+ 
+void xs_audioout_get_volume_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	xsmcSetNumber(xsResult, audioOut->volumeDouble);
+}
+ 
+void xs_audioout_set_volume_(xsMachine *the)
+{
+	AudioOut audioOut = xsmcGetHostDataValidate(xsThis, (void *)&xsAudioOutHooks);
+	double volume = xsmcToNumber(xsArg(0));
+	if ((volume < 0) || (volume > 1))
+		xsRangeError("invalid volume");
+	audioOut->volumeDouble = volume;
+	audioOut->volumeFixed = (int16_t)(volume * 256);
+}
+ 
+void xs_audioout_mark_(xsMachine* the, void* it, xsMarkRoot markRoot)
+{
+	AudioOut audioOut = it;
+	AudioOutElement walker;
+
+	if (audioOut->onWritable)
+		(*markRoot)(the, audioOut->onWritable);
+
+	for (walker = audioOut->elements; C_NULL != walker; walker = walker->next) {
+		if (walker->buffer)
+			(*markRoot)(the, walker->buffer);
+		if (walker->completion)
+			(*markRoot)(the, walker->completion);
+	}
+}
+
+static bool playedBuffer(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx)
+{
+	AudioOut audioOut = user_ctx;
+	BaseType_t higherPriorityTaskWoken = pdFALSE;
+
+//@@ entire operation on audioOut->bytesWritable should be atomic
+	uint32_t bytesWritable = __atomic_add_fetch(&audioOut->bytesWritable, event->size, __ATOMIC_SEQ_CST);
+	if (bytesWritable > audioOut->total_dma_buf_size)
+		audioOut->bytesWritable = audioOut->total_dma_buf_size;
+
+	if (audioOut->elements) {
+		AudioOutElement walker;
+		uint32_t bytesAvailable = 0;
+		for (walker = audioOut->elements; NULL != walker; walker = walker->next) {
+			if (!walker->bytesAvailable)		// buffer already used
+				continue;
+			if (C_NULL == walker->data)			// relocatable buffer
+				break;
+			bytesAvailable += walker->bytesAvailable;
+			if (bytesAvailable >= audioOut->dma_buf_size) {
+				xTaskNotifyFromISR(audioOut->task, 1, eSetValueWithOverwrite, &higherPriorityTaskWoken);	// wake task
+				if (higherPriorityTaskWoken)
+					portYIELD_FROM_ISR();
+				return false;		// won't invoke audiooutDeliver / onWritable 
+			}
+		}
+	}
+
+	if (!audioOut->callbackPending) {
+		__atomic_add_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+		audioOut->callbackPending = true;
+		if (0 != modMessagePostToMachineFromISR(audioOut->the, audiooutDeliver, audioOut)) {
+			audioOut->callbackPending = false;
+			__atomic_sub_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+		}
+	}
+    return false;
+}
+
+static void audiooutDeliver(void *theIn, void *refcon, uint8_t *message, uint16_t messageLength)
+{
+	xsMachine *the = (xsMachine *)theIn;
+	AudioOut audioOut = (AudioOut)refcon;
+
+	if (1 == audioOut->useCount)
+		goto done;
+
+	audioOut->callbackPending = false;
+	xsBeginHost(the);
+
+	if (audioOut->bytesWritable) {
+		AudioOutElement element;
+		if (audioOut->onWritable) {
+			uint32_t bytesWritable = audioOut->bytesWritable;
+			
+			for (element = audioOut->elements; C_NULL != element; element = element->next) {
+				if (element->bytesAvailable >= bytesWritable) {
+					bytesWritable = 0;
+					break;
+				}
+				bytesWritable -= element->bytesAvailable;
+			}
+
+			if (bytesWritable) {
+				xsTry {
+					xsmcSetInteger(xsResult, audioOut->bytesWritable - audioOut->stagingOffset);
+					xsCallFunction1(xsReference(audioOut->onWritable), audioOut->obj, xsResult);
+				}
+				xsCatch {
+				}
+				if (audioOut->useCount == 0) goto abort;
+			}
+		}
+		
+		if (audioOut->bytesWritable && audioOut->elements) {
+			for (element = audioOut->elements; (C_NULL != element) && audioOut->bytesWritable; element = element->next) {
+				int use = audioOut->bytesWritable;
+				if (use > element->bytesAvailable)
+					use = element->bytesAvailable;
+				if (!use)
+					continue;
+
+				void *data = element->data;
+				if (!data) {
+					xsUnsignedValue currentSize;
+					xsResult = xsReference(element->buffer);
+					xsmcGetBufferReadable(xsResult, &data, &currentSize);
+					
+					if ((element->position + use) > currentSize) {		// buffer resized to smaller than original request
+						element->err = 1;
+						element->bytesAvailable = 0;
+						continue;
+					}
+				}
+
+				element->err = doWrite(audioOut, element->position + (uint8_t *)data, use);
+				element->position += use;
+				element->bytesAvailable -= use;
+				if (element->err)
+					element->bytesAvailable = 0;
+			}
+		}
+	}
+
+	while (audioOut->elements && (0 == audioOut->elements->bytesAvailable)) { 
+		AudioOutElement element = audioOut->elements;
+		audioOut->elements = element->next;
+
+		if (element->completion) {
+			xsTry {
+				if (element->err) {
+					xsmcSetInteger(xsResult, element->err);
+					xsResult = xsNew1(xsGlobal, xsID_Error, xsResult);
+				}
+				else
+					xsmcSetNull(xsResult);
+				xsCallFunction1(xsReference(element->completion), audioOut->obj, xsResult);
+			}
+			xsCatch {
+			}
+		}
+		c_free(element);
+		if (audioOut->useCount == 0) goto abort;
+	}
+
+abort:
+	xsEndHost(the);
+	
+done:
+	if (0 == __atomic_sub_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST)) {
+		c_free(audioOut);
+		return;
+	}
+
+}
+
+esp_err_t doWrite(AudioOut audioOut, void *buffer, xsUnsignedValue requested)
+{
+	esp_err_t err = ESP_OK;
+	uint8_t *src = (uint8_t *)buffer;
+	const int kTimeout = 200;
+
+	while (requested > 0 && ESP_OK == err) {
+		if ((256 == audioOut->volumeFixed) && (0 == audioOut->stagingOffset) && (requested >= audioOut->dma_buf_size)) {
+			size_t bytes_written;
+			if (audioOut->started)
+				err = i2s_channel_write(audioOut->tx_handle, src, audioOut->dma_buf_size, &bytes_written, kTimeout);
+			else
+				err = i2s_channel_preload_data(audioOut->tx_handle, src, audioOut->dma_buf_size, &bytes_written);
+			__atomic_fetch_sub(&audioOut->bytesWritable, audioOut->dma_buf_size, __ATOMIC_SEQ_CST);
+			src += audioOut->dma_buf_size;
+			requested -= audioOut->dma_buf_size;
+		}
+		else {
+			uint32_t stagingSpace = audioOut->dma_buf_size - audioOut->stagingOffset;
+			uint32_t use = (requested < stagingSpace) ? (uint32_t)requested : stagingSpace;
+
+			if (256 == audioOut->volumeFixed)
+				c_memcpy(audioOut->stagingBuffer + audioOut->stagingOffset, src, use);
+			else {
+				int16_t *dst = (int16_t *)(audioOut->stagingBuffer + audioOut->stagingOffset);
+				int16_t *s = (int16_t *)src;
+				int16_t vol = audioOut->volumeFixed;
+				uint32_t samples = use >> 1;
+				for (uint32_t i = 0; i < samples; i++)
+					dst[i] = (s[i] * vol) >> 8;
+			}
+
+			audioOut->stagingOffset += use;
+			src += use;
+			requested -= use;
+
+			if (audioOut->stagingOffset == audioOut->dma_buf_size) {
+				size_t bytes_written;
+				if (audioOut->started)
+					err = i2s_channel_write(audioOut->tx_handle, audioOut->stagingBuffer, audioOut->dma_buf_size, &bytes_written, kTimeout);
+				else
+					err = i2s_channel_preload_data(audioOut->tx_handle, audioOut->stagingBuffer, audioOut->dma_buf_size, &bytes_written);
+				__atomic_fetch_sub(&audioOut->bytesWritable, audioOut->dma_buf_size, __ATOMIC_SEQ_CST);
+				audioOut->stagingOffset = 0;
+			}
+		}
+	}
+
+	return err;
+}
+
+void audioOutLoop(void *pvParameter)
+{
+	AudioOut audioOut = (AudioOut)pvParameter;
+
+	while (true) {
+		uint32_t newState;
+		uint8_t doCallback = 0;
+		AudioOutElement element;
+
+		xTaskNotifyWait(0, 0, &newState, portMAX_DELAY);
+		if (2 == newState)
+			break;
+
+		for (element = audioOut->elements; (C_NULL != element) && audioOut->bytesWritable; element = element->next) {
+			int use = audioOut->bytesWritable;
+			if (use > element->bytesAvailable)
+				use = element->bytesAvailable;
+			if (!use)
+				continue;
+
+			void *data = element->data;
+			if (C_NULL == data) {		// cannot access relocatable data from here. should never get here.... because playedBuffer checks 
+				doCallback = 1;
+				break;
+			}
+
+			element->err = doWrite(audioOut, element->position + (uint8_t *)data, use);
+			if (element->err)
+				element->bytesAvailable = 0;
+			else
+				element->bytesAvailable -= use;
+			element->position += use;
+
+			if (0 == element->bytesAvailable) {
+				element->buffer = C_NULL;
+				doCallback = 1;
+			}
+		}
+
+		if (doCallback && !audioOut->callbackPending) {
+			audioOut->callbackPending = true;
+			__atomic_add_fetch(&audioOut->useCount, 1, __ATOMIC_SEQ_CST);
+			modMessagePostToMachine(audioOut->the, C_NULL, 0, audiooutDeliver, audioOut);
+		}
+	}
+
+	audioOut->task = NULL;
+
+	vTaskDelete(NULL);	// "If it is necessary for a task to exit then have the task call vTaskDelete( NULL ) to ensure its exit is clean."
+}

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32.js
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024-2026  Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class AudioOut extends Native('xs_audioout_destructor_') {
+  constructor(dictionary) {
+    super()
+    native('xs_audioout_constructor_').call(this, dictionary)
+  }
+  close() {
+    return native('xs_audioout_close_').call(this)
+  }
+  start() {
+    return native('xs_audioout_start_').call(this)
+  }
+  stop() {
+    return native('xs_audioout_stop_').call(this)
+  }
+  write(samples) {
+    return native('xs_audioout_writeSync_').call(this, samples)
+  }
+
+  get format() {
+    return native('xs_audioout_get_format_').call(this)
+  }
+  set format(it) {
+    native('xs_audioout_set_format_').call(this, it)
+  }
+
+  get bitsPerSample() {
+    return native('xs_audioout_get_bitsPerSample_').call(this)
+  }
+  get channels() {
+    return native('xs_audioout_get_numChannels_').call(this)
+  }
+  get sampleRate() {
+    return native('xs_audioout_get_sampleRate_').call(this)
+  }
+  get audioType() {
+    return 'LPCM'
+  }
+
+  get volume() {
+    return native('xs_audioout_get_volume_').call(this)
+  }
+  set volume(it) {
+    native('xs_audioout_set_volume_').call(this, it)
+  }
+
+  static {
+    this.prototype[Symbol.dispose] = this.prototype.close
+  }
+}
+
+AudioOut.Async = class extends AudioOut {
+  write(samples, callback) {
+    return native('xs_audioout_writeAsync_').call(this, samples, callback)
+  }
+}
+
+export default AudioOut

--- a/firmware/host/platforms/m5stackchan_cores3/manifest.json
+++ b/firmware/host/platforms/m5stackchan_cores3/manifest.json
@@ -14,7 +14,13 @@
     "setup/m5stackchan-power": "./setup-target",
     "stackchan-sdcard": "./sd-card",
     "pins/audioout-original": "$(MODULES)/pins/i2s/audioout",
-    "pins/audioout": "../core_s3_audioout"
+    "pins/audioout": "../core_s3_audioout",
+    "stackchanCores3AudioOutNative": "../../modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32",
+    "stackchanCores3AudioInNative": "../../modules/audio/platforms/m5stackchan-cores3/io-audioin/audioin",
+    "cores3I2SBus": "../../modules/audio/platforms/m5stackchan-cores3/cores3-i2s-bus",
+    "embedded:io/audio/out-original": "../../modules/audio/platforms/m5stackchan-cores3/io-audioout/audioout-esp32",
+    "embedded:io/audio/out": "../../modules/audio/platforms/m5stackchan-cores3/cores3-audio-out",
+    "embedded:io/audio/in": "../../modules/audio/platforms/m5stackchan-cores3/cores3-audio-in"
   },
   "platforms": {
     "esp32/m5stackchan_cores3": {


### PR DESCRIPTION
## What changed

- Overlay CoreS3 `embedded:io/audio/out` and `embedded:io/audio/in` instead of changing Moddable upstream.
- AudioOut now uses the manifest I2S port (`I2S1`) and IDF Philips/MSB slot macros.
- CoreS3 AudioOut no longer drives MCLK on GPIO0. That pin stays with ES7210.
- AudioIn opens the RX channel in READY and enables it only on `start()`.
- A single bus owner starts/stops AW88298 and ES7210 when the half-duplex role changes.

## Why

CoreS3 shares BCLK/WS between the speaker and microphone. The current half-duplex JS path still let AudioOut take `I2S_NUM_AUTO`, drive ES7210's MCLK, and leave RX enabled before `start()`. That is enough to corrupt the next microphone turn after 24 kHz playback.

This is independent of XiaoZhi. `#659` can rebase onto this branch.

## Release impact

**Patch.** M5StackChan CoreS3 only. Other targets keep the stock Moddable drivers.

## Validation

- `cd firmware && npm run format && npm run lint && npm run check:architecture && npm run test:unit` — 399 tests passed
- CoreS3 firmware build/flash and listen/speak switching were **not** run in this environment

## Follow-up

- Rebase `agent/xiaozhi-opus-v1` (`#659`) onto this branch
- Confirm first utterance vs post-TTS utterance STT on hardware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio input and output support for the M5Stack CoreS3.
  * Added microphone capture with configurable formats, levels, buffering, and lifecycle controls.
  * Added speaker playback with synchronous and asynchronous writing, volume control, and standard audio settings.
  * Added automatic coordination between microphone and speaker access to prevent conflicts.
  * Configured CoreS3 audio routing, I2S settings, and pin assignments.

* **Bug Fixes**
  * Improved cleanup and resource handling when audio initialization or shutdown encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->