### PR TITLE
fix(chat): bind XiaoZhi PCM writer to CoreS3 native module

### DIFF
--- a/.changeset/native-xiaozhi-pcm.md
+++ b/.changeset/native-xiaozhi-pcm.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Bind the XiaoZhi PCM ring writer to the native CoreS3 implementation while keeping the fallback isolated from unsupported targets.

--- a/firmware/host/modules/audio/__tests__/audio-buffer-ownership.architecture.ts
+++ b/firmware/host/modules/audio/__tests__/audio-buffer-ownership.architecture.ts
@@ -64,6 +64,20 @@ test('M5StackChan CoreS3 excludes the fallback stackchan-voice module before sel
   assert.equal(modules.stackchanOpusEncoder, './platforms/m5stackchan-cores3/esp32-opus-encoder')
 })
 
+test('M5StackChan CoreS3 excludes the generic PCM writer before selecting its target adapter', () => {
+  const manifest = JSON.parse(readFileSync('host/modules/conversation/manifest.json', 'utf8')) as {
+    modules: Record<string, string>
+    platforms: Record<string, { modules: Record<string, string | string[]> }>
+  }
+  const fallback = manifest.modules.stackchanPcmRingWriter
+  const modules = manifest.platforms['esp32/m5stackchan_cores3'].modules
+
+  assert.ok(Array.isArray(modules['~']))
+  assert.ok(modules['~'].includes(fallback))
+  assert.equal(modules.stackchanPcmRingWriter, './chat-audioio/pcm-ring-writer-native')
+  assert.notEqual(modules.stackchanPcmRingWriter, fallback)
+})
+
 test('XiaoZhi uplink has one native SPSC path without spin locks', () => {
   const workerStack = readFileSync('host/modules/conversation/chat-audioio/worker-stack.js', 'utf8')
   const encoder = readFileSync('host/modules/audio/platforms/m5stackchan-cores3/esp32-opus-encoder.c', 'utf8')

--- a/firmware/host/modules/conversation/chat-audioio/pcm-ring-writer-native.js
+++ b/firmware/host/modules/conversation/chat-audioio/pcm-ring-writer-native.js
@@ -1,0 +1,1 @@
+export { writePcmRing } from 'stackchanOpusEncoder'

--- a/firmware/host/modules/conversation/manifest.json
+++ b/firmware/host/modules/conversation/manifest.json
@@ -26,9 +26,9 @@
         "./chat-audioio/server.manifest.json"
       ],
       "modules": {
-        "~": "./StackChanChatAudioIO",
+        "~": ["./StackChanChatAudioIO", "./chat-audioio/pcm-ring-writer"],
         "StackChanChatAudioIO": "./chat-audioio/worker-stack",
-        "stackchanPcmRingWriter": "../audio/platforms/m5stackchan-cores3/esp32-opus-encoder"
+        "stackchanPcmRingWriter": "./chat-audioio/pcm-ring-writer-native"
       },
       "defines": {
         "audioIn": {


### PR DESCRIPTION
## Summary

- keep the throwing PCM writer fallback for targets without the native encoder
- select the existing CoreS3 native PCM ring implementation for `m5stackchan_cores3`
- add an architecture test that prevents the target from selecting the generic fallback again

## Root cause

`fffc3c6` correctly isolated the native symbol so `m5stack_cores3` could link, but the generated M5StackChan build selected the generic fallback module instead of the target mapping. Starting a voice session therefore threw `PCM ring writer is unavailable on this target`.

## Verification

- `npm run check:architecture` — 78 passed
- `npm test` — 397 passed
- `npm run lint` — no errors (one pre-existing informational diagnostic)
- `npm run build:release:m5stack_cores3`
- `npm run build:release:m5stackchan_cores3`
- generated M5StackChan makefile selects `pcm-ring-writer-native.js` and links `xs_pcm_ring_write_downmix`
- physical CoreS3 `44:1b:f6:e2:99:a4`, USB Audio disabled: CONNECTING → CONNECTED → SPEAKING → LISTENING → SPEAKING; 161 uplink packets, `dropped_pcm=0B`; 290 downlink packets; no reboot or fallback exception
- production Worker recorded `session_ready`, speech start/stop, response completion, and a return to listening for the same device/session

## Release impact

patch — fixes voice-session startup on M5StackChan CoreS3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved audio handling on M5Stack CoreS3 devices by using the platform’s native PCM audio path.
  * Increased playback reliability by preventing unsupported audio fallbacks from being selected.
  * Added safeguards to ensure the appropriate audio implementation is used for CoreS3 hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->