### PR TITLE
fix(host): disable USB audio Dock by default

### DIFF
--- a/.changeset/quiet-usb-audio-default.md
+++ b/.changeset/quiet-usb-audio-default.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Disable the Android USB audio Dock by default while allowing dedicated hosts and installed MOD manifests to opt in at boot.

--- a/firmware/docs/android-usb-audio.md
+++ b/firmware/docs/android-usb-audio.md
@@ -18,12 +18,15 @@ npm run flash:android-usb-audio
 ```
 
 専用manifestは`host/app/manifest_android_usb_audio.json`である。
-このmanifestは標準CoreS3構成を読み込み、`config.usbAudio.autoStart=true`でUSB dockを自動起動する。
+このmanifestは標準CoreS3構成を読み込み、`config.usbAudio.enabled=true`と`autoStart=true`でUSB dockを自動起動する。
 通常再生時の`AudioOut.volume`は、起動設定で保存した`tts.volume`を使う。
 DockはUSB物理ブリッジの起動時に保存値を読み、起動設定の終了後に再読込して同じboot中の変更も反映する。
 診断manifestは明示的な`config.usbAudio.speakerVolume=0`を優先し、無音を維持する。
-標準CoreS3 manifestにもUSB dockは組み込まれるが、`autoStart=false`であるためMODが`activate()`するまで論理セッションを起動しない。
-標準CoreS3 manifestでも、USBSerialとworkerを含む物理USBブリッジはhost起動時に一度だけ確保する。
+標準CoreS3 manifestは`config.usbAudio.enabled=false`であり、USB物理ブリッジと`remoteSession`を作成しない。
+USB機能を必要とするMODは、自身のmanifestへ`"usbAudio": { "enabled": true }`をconfigとして宣言する。
+hostはこの`mod/config`を`onLaunch()`より前に読み、USBSerialとworkerを含む物理USBブリッジを起動時に一度だけ確保する。
+MODの`onLaunch()`から動的に有効化する方式ではないため、連続したnative ringをWi-Fiやruntime contextより先に確保できる。
+MOD宣言で有効化した場合は標準manifestの`autoStart=false`を維持し、`onContextCreated()`で`remoteSession.activate()`を呼ぶまで論理セッションを起動しない。
 application EVENT runtimeもhost起動時に作り、MOD有効化前に届いたタスク状態を保持する。
 この常駐runtimeはraw EVENT transport、タスク状態のsnapshot、会話要求の再送と結果照合を所有する。
 Androidから`session.created`が先に届いても、MODが`activate()`して実際のtool providerを渡すまでは`session.update`を送らない。
@@ -45,7 +48,7 @@ AndroidはLLM応答開始時のtool catalogをsnapshotし、function callへそ�
 M5StackChan CoreS3用manifestは、このモジュール名をUSB Dock実装へ割り当てる。
 共有host manifestとWASM版はUSB transport、remote session、承認画面をbundleしない。
 
-標準CoreS3 hostの`robot.conversation.remoteSession`は、会話表示をまだ有効化していないinactive状態から始まる。
+USB Audioを有効にしたhostの`robot.conversation.remoteSession`は、会話表示をまだ有効化していないinactive状態から始まる。
 USB機能を使うMODは、状態購読や会話要求より前に`remoteSession.activate()`を呼ぶ。
 `activate()`は冪等であり、成功後の`activationState`は`active`になる。
 `deactivate()`は`conversation.stop`を常駐会話制御sessionへ先にqueueし、会話状態ハンドラと状態表示の購読を外して、同じfacadeを再びactivateできる状態へ戻す。

--- a/firmware/host/app/dock.test.ts
+++ b/firmware/host/app/dock.test.ts
@@ -27,9 +27,17 @@ test('an unconfigured Stackchan Dock is optional', () => {
 
 test('the configured Stackchan Dock starts and returns its runtime', () => {
   const runtime = fakeRuntime()
-  const dock: StackchanDock = { start: () => runtime }
+  const modConfig = { usbAudio: { enabled: true } }
+  let receivedConfig: unknown
+  const dock: StackchanDock = {
+    start: (received) => {
+      receivedConfig = received
+      return runtime
+    },
+  }
 
-  assert.equal(startStackchanDock(new FakeModules(dock)), runtime)
+  assert.equal(startStackchanDock(new FakeModules(dock), modConfig), runtime)
+  assert.equal(receivedConfig, modConfig)
 })
 
 test('a Dock may be present but disabled by its own configuration', () => {

--- a/firmware/host/app/dock.ts
+++ b/firmware/host/app/dock.ts
@@ -9,7 +9,7 @@ export type StackchanDockRuntime = {
 }
 
 export type StackchanDock = {
-  start(): StackchanDockRuntime | undefined
+  start(modConfig?: unknown): StackchanDockRuntime | undefined
 }
 
 export type StackchanDockModules = {
@@ -17,13 +17,16 @@ export type StackchanDockModules = {
   importNow(specifier: string): unknown
 }
 
-export function startStackchanDock(modules: StackchanDockModules): StackchanDockRuntime | undefined {
+export function startStackchanDock(
+  modules: StackchanDockModules,
+  modConfig?: unknown,
+): StackchanDockRuntime | undefined {
   if (!modules.has(STACKCHAN_DOCK_MODULE)) return
   const dock = modules.importNow(STACKCHAN_DOCK_MODULE)
   if (!isStackchanDock(dock)) {
     throw new TypeError(`${STACKCHAN_DOCK_MODULE} does not export a StackchanDock`)
   }
-  const runtime = dock.start()
+  const runtime = dock.start(modConfig)
   if (runtime === undefined) return
   if (!isStackchanDockRuntime(runtime)) {
     throw new TypeError(`${STACKCHAN_DOCK_MODULE} returned an invalid runtime`)

--- a/firmware/host/app/docks/android-usb-audio/dock.ts
+++ b/firmware/host/app/docks/android-usb-audio/dock.ts
@@ -8,14 +8,19 @@ import type { RealtimeToolProvider } from 'stackchan-realtime-session'
 import { createRemoteSessionRuntime } from 'stackchan-remote-session-runtime'
 import type { UsbAudioPresentation } from 'stackchan-usb-dock-presentation'
 import { usbAudioConversationState } from 'stackchan-usb-dock-presentation-model'
-import { createUsbAudioDockRuntime, type UsbAudioBridgeControl, type UsbAudioConfig } from 'stackchan-usb-dock-runtime'
+import {
+  createUsbAudioDockRuntime,
+  resolveUsbAudioConfig,
+  type UsbAudioBridgeControl,
+  type UsbAudioConfig,
+} from 'stackchan-usb-dock-runtime'
 import type { StackChanStatus } from 'stackchan-usb-media-session'
 import Timer from 'timer'
 import { canonicalizeVolume } from 'volume-model'
 
 const stackchanUsbDock: StackchanDock = {
-  start() {
-    const usbAudio = (config as { usbAudio?: UsbAudioConfig }).usbAudio
+  start(modConfig) {
+    const usbAudio = resolveUsbAudioConfig((config as { usbAudio?: UsbAudioConfig }).usbAudio, modConfig)
     if (!usbAudio?.enabled) return
     const configuredSpeakerVolume = usbAudio.speakerVolume
     const resolveSavedSpeakerVolume = () => canonicalizeVolume(loadPreferences(DOMAIN.tts).volume)

--- a/firmware/host/app/docks/android-usb-audio/runtime.test.ts
+++ b/firmware/host/app/docks/android-usb-audio/runtime.test.ts
@@ -22,7 +22,22 @@ import type {
 
 installRemoteSessionTestAliases()
 
-const { createUsbAudioDockRuntime } = await import('./runtime.js')
+const { createUsbAudioDockRuntime, resolveUsbAudioConfig } = await import('./runtime.js')
+
+test('MOD config may opt into USB audio without overriding host startup policy', () => {
+  const defaultConfig: UsbAudioConfig = { enabled: false, autoStart: false }
+  const dedicatedConfig: UsbAudioConfig = { enabled: true, autoStart: true }
+
+  assert.deepEqual(resolveUsbAudioConfig(defaultConfig, undefined), defaultConfig)
+  assert.deepEqual(resolveUsbAudioConfig(defaultConfig, { usbAudio: { enabled: true } }), {
+    enabled: true,
+    autoStart: false,
+  })
+  assert.deepEqual(resolveUsbAudioConfig(dedicatedConfig, { usbAudio: { enabled: false } }), dedicatedConfig)
+  assert.equal(resolveUsbAudioConfig(undefined, { usbAudio: 'invalid' }), undefined)
+  assert.deepEqual(resolveUsbAudioConfig(defaultConfig, { usbAudio: { enabled: 1 } }), defaultConfig)
+  assert.deepEqual(resolveUsbAudioConfig(defaultConfig, { usbAudio: { enabled: 'true' } }), defaultConfig)
+})
 
 class FakeRemoteSession implements RemoteConversationSessionDelegate {
   state: RemoteConversationState = 'standby'

--- a/firmware/host/app/docks/android-usb-audio/runtime.ts
+++ b/firmware/host/app/docks/android-usb-audio/runtime.ts
@@ -42,6 +42,14 @@ export type UsbAudioConfig = UsbAudioBridgeOptions & {
   presentationEnabled?: boolean
 }
 
+export function resolveUsbAudioConfig(
+  hostConfig: UsbAudioConfig | undefined,
+  modConfig: unknown,
+): UsbAudioConfig | undefined {
+  const enabledByMod = (modConfig as { usbAudio?: { enabled?: unknown } } | null)?.usbAudio?.enabled === true
+  return enabledByMod ? { ...(hostConfig ?? {}), enabled: true } : hostConfig
+}
+
 type StartUsbAudioBridge<Status> = (options?: UsbAudioBridgeOptions) => UsbAudioBridgeControl<Status>
 
 export type UsbAudioRemoteActivation = {

--- a/firmware/host/app/main.ts
+++ b/firmware/host/app/main.ts
@@ -1,4 +1,4 @@
-import loadPreferences, { loadPreferenceConfig } from 'loadPreference'
+import loadPreferences, { loadModConfig, loadPreferenceConfig } from 'loadPreference'
 import { runContextCreatedBehaviors, type StackchanAppBehavior } from 'app-behavior'
 import { resolveAppBehaviors } from 'app-behavior-resolver'
 import defaultBehavior from 'app-default-behavior'
@@ -98,7 +98,7 @@ async function main() {
   let dockRuntime: StackchanDockRuntime | undefined
   let context: StackchanContext | undefined
   try {
-    dockRuntime = startStackchanDock(Modules)
+    dockRuntime = startStackchanDock(Modules, loadModConfig())
     if (dockRuntime) trace('[main] Stackchan Dock started\n')
     installPlatformInputBridge()
     initializeLocalization(loadPreferences(DOMAIN.ui).language)

--- a/firmware/host/app/manifest_m5stackchan_cores3.json
+++ b/firmware/host/app/manifest_m5stackchan_cores3.json
@@ -11,7 +11,7 @@
   "config": {
     "enablePowerButton": true,
     "usbAudio": {
-      "enabled": true,
+      "enabled": false,
       "autoStart": false
     }
   }

--- a/firmware/host/modules/preferences/loadPreference.ts
+++ b/firmware/host/modules/preferences/loadPreference.ts
@@ -12,7 +12,7 @@ export type PreferenceConfig = Record<PreferenceDomain, ConfigRecord>
 const LEGACY_RENDERER_DOMAIN = 'renderer'
 let modConfig: ConfigRecord | undefined
 
-function loadModConfig(): ConfigRecord {
+export function loadModConfig(): ConfigRecord {
   if (modConfig) return modConfig
   try {
     modConfig = Modules.has('mod/config') ? (Modules.importNow('mod/config') as ConfigRecord) : {}

--- a/firmware/host/modules/usb-audio/usb-audio.architecture.ts
+++ b/firmware/host/modules/usb-audio/usb-audio.architecture.ts
@@ -88,7 +88,7 @@ test('USB transport stays platform-specific while physical audio remains on the 
 })
 
 test('release and diagnostic manifests compose the same USB Dock in layers', () => {
-  assert.equal(coreS3Manifest.config?.usbAudio?.enabled, true)
+  assert.equal(coreS3Manifest.config?.usbAudio?.enabled, false)
   assert.equal(coreS3Manifest.config?.usbAudio?.autoStart, false)
   assert.equal(coreS3Manifest.config?.usbAudio?.speakerVolume, undefined)
   assert.equal(usbAppManifest.config?.usbAudio?.enabled, true)


### PR DESCRIPTION
## Summary

- disable the Android USB audio Dock in the default CoreS3 host
- let an installed MOD opt in declaratively with `config.usbAudio.enabled: true`
- keep the dedicated Android USB audio host manifest as an explicit opt-in path
- update tests and documentation for all three startup modes

## Startup model

`startStackchanDock()` still runs before MOD behavior import, `onLaunch()`, Wi-Fi, and runtime-context construction. It reads only the lightweight `mod/config` module first. This lets a USB-capable MOD request the native bridge while internal RAM is still contiguous, without enabling it for unrelated MODs.

A MOD opt-in only changes `enabled` to true; it cannot override host policy such as `autoStart`. With the standard host, `autoStart` remains false and the MOD activates the logical session from `onContextCreated()`. The dedicated `manifest_android_usb_audio.json` remains `enabled: true, autoStart: true`. Runtime toggling from `onLaunch()` is deliberately not used because it would allocate the 32 KiB RX and 16 KiB TX native rings after heavier startup work.

## Verification

- unit tests: 398 passed
- architecture tests: 78 passed
- Biome format and lint: passed (one existing informational lint only)
- `npm run build:release:m5stackchan_cores3`: passed with the default disabled
- `npm run build:android-usb-audio`: passed with the dedicated manifest enabled
- physical XiaoZhi E2E already passed with the identical USB-audio-disabled host configuration: multiple speech turns, LISTENING/SPEAKING transitions, no dropped PCM, no reboot

## Release impact

Patch change. USB audio users can use the dedicated host build or declare `usbAudio.enabled: true` in the installed MOD manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - USB audio is now disabled by default on the M5Stack CHAN CoreS3 host.
  - Dedicated USB audio builds and installed MODs can opt in at startup.
  - USB audio session startup remains separately controlled by its auto-start setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->