### PR TITLE
feat(ui): refine Stack-chan AI device interactions

### DIFF
--- a/.changeset/steady-head-touch-ui.md
+++ b/.changeset/steady-head-touch-ui.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": minor
+---
+
+Add stable head-tap metadata and multi-listener touch-panel subscriptions, keep the microphone indicator visible during user input, and reuse speech balloons for streaming text updates.

--- a/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
+++ b/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
@@ -27,14 +27,23 @@ const balloonMessages: string[] = []
 const torqueRequests: boolean[] = []
 let servoFailure: Error | undefined
 let drawerCloseCount = 0
+type TouchPanelTestEvent = {
+  gesture: 'forwardSwipe' | 'backwardSwipe'
+  position: number
+  intensity: number
+  ticks: number
+}
 const touchPanel: {
-  onEvent?: (event: {
-    gesture: 'forwardSwipe' | 'backwardSwipe'
-    position: number
-    intensity: number
-    ticks: number
-  }) => void
-} = {}
+  listener?: (event: TouchPanelTestEvent) => void
+  subscribe: (listener: (event: TouchPanelTestEvent) => void) => () => void
+} = {
+  subscribe(listener) {
+    touchPanel.listener = listener
+    return () => {
+      if (touchPanel.listener === listener) touchPanel.listener = undefined
+    }
+  },
+}
 
 const robot = {
   audio: {
@@ -174,9 +183,9 @@ assert(
 )
 const speakButton = buttons.find((button) => button.key === 'speakStackchan')
 assert(speakButton, 'speakStackchan button should be registered')
-assert(touchPanel.onEvent, 'touchPanel handler should be registered')
-touchPanel.onEvent?.({ gesture: 'forwardSwipe', position: 0.25, intensity: 3, ticks: 100 })
-touchPanel.onEvent?.({ gesture: 'backwardSwipe', position: 0.75, intensity: 3, ticks: 500 })
+assert(touchPanel.listener, 'touchPanel subscriber should be registered')
+touchPanel.listener?.({ gesture: 'forwardSwipe', position: 0.25, intensity: 3, ticks: 100 })
+touchPanel.listener?.({ gesture: 'backwardSwipe', position: 0.75, intensity: 3, ticks: 500 })
 equal(emotions[emotions.length - 1], Emotion.HAPPY, 'petting swipe pair should set HAPPY emotion')
 assert(effects.length > 0, 'petting should add a visible emotion effect')
 

--- a/firmware/host/app/default-behavior/on-context-created.ts
+++ b/firmware/host/app/default-behavior/on-context-created.ts
@@ -641,7 +641,7 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
   if (robot.touchPanel != null) {
     let lastForwardSwipeTicks: number | undefined
     let lastBackwardSwipeTicks: number | undefined
-    robot.touchPanel.onEvent = (event) => {
+    robot.touchPanel.subscribe((event) => {
       const type = event.gesture
       trace(`[TouchPanel] gesture: ${type}\n`)
       if (type !== 'forwardSwipe' && type !== 'backwardSwipe') return
@@ -702,6 +702,6 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
         lastForwardSwipeTicks = undefined
         lastBackwardSwipeTicks = undefined
       }
-    }
+    })
   }
 }

--- a/firmware/host/app/runtime-ui.ts
+++ b/firmware/host/app/runtime-ui.ts
@@ -42,8 +42,20 @@ type RuntimeUIOptions = {
   isPaused: () => boolean
 }
 
+const BALLOON_OPTION_KEYS = ['left', 'right', 'top', 'bottom', 'width', 'height', 'tail'] as const
+
+type SpeechBalloonBehavior = {
+  setText?: (content: UIEffect, text: string) => void
+}
+
+function sameBalloonOptions(current: ShowBalloonOptions | null, next: ShowBalloonOptions): boolean {
+  if (!current) return false
+  return BALLOON_OPTION_KEYS.every((key) => current[key] === next[key])
+}
+
 export class StackchanRuntimeUI {
   #balloon: UIEffect | null = null
+  #balloonOptions: ShowBalloonOptions | null = null
   #drawerButtonSpecs = new Map<string, DrawerButtonSpec>()
   #drawerButtonStates = new Map<string, boolean>()
   #drawerRegistry: DrawerCapability
@@ -86,10 +98,16 @@ export class StackchanRuntimeUI {
   }
 
   showBalloon(text: string, option: ShowBalloonOptions = {}) {
-    if (this.#balloon != null) {
-      this.hideBalloon()
+    if (this.#balloon != null && sameBalloonOptions(this.#balloonOptions, option)) {
+      const behavior = this.#balloon.behavior as SpeechBalloonBehavior | undefined
+      if (behavior?.setText) {
+        behavior.setText(this.#balloon, text)
+        return
+      }
     }
+    this.hideBalloon()
     this.#balloon = new SpeechBalloon({ ...option, text })
+    this.#balloonOptions = { ...option }
     this.#ui.addEffect(this.#balloon)
   }
 
@@ -97,6 +115,7 @@ export class StackchanRuntimeUI {
     if (this.#balloon != null) {
       this.#ui.removeEffect(this.#balloon)
       this.#balloon = null
+      this.#balloonOptions = null
     }
   }
 

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/xiaozhi-contract.test.ts
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/xiaozhi-contract.test.ts
@@ -1,11 +1,11 @@
 import { equal } from 'testing/assert'
 import {
+  type JsonRpcMessage,
   parseJsonRpcMessage,
   parseXiaozhiGlyphPushV1,
   parseXiaozhiV1ClientEvent,
   parseXiaozhiV1ServerEvent,
   sanitizeXiaozhiV1HelloExtension,
-  type JsonRpcMessage,
 } from 'xiaozhi-contract'
 
 trace('=== xiaozhi-contract test ===\n')

--- a/firmware/host/modules/input/__tests__/touch-panel/manifest.test.json
+++ b/firmware/host/modules/input/__tests__/touch-panel/manifest.test.json
@@ -1,0 +1,11 @@
+{
+  "include": ["../../manifest.json", "../../../testing/manifest.json"],
+  "modules": {
+    "main": "./touch-panel.test"
+  },
+  "defines": {
+    "main": {
+      "async": 1
+    }
+  }
+}

--- a/firmware/host/modules/input/__tests__/touch-panel/touch-panel.test.ts
+++ b/firmware/host/modules/input/__tests__/touch-panel/touch-panel.test.ts
@@ -1,8 +1,8 @@
 import type { TouchPanelInputEvent } from 'input-event'
+import { assert, equal } from 'testing/assert'
 import Time from 'time'
 import Timer from 'timer'
 import TouchPanel from 'touch-panel'
-import { assert, equal } from 'testing/assert'
 
 class FakeTouchPanelDriver {
   static current: FakeTouchPanelDriver | undefined

--- a/firmware/host/modules/input/__tests__/touch-panel/touch-panel.test.ts
+++ b/firmware/host/modules/input/__tests__/touch-panel/touch-panel.test.ts
@@ -1,0 +1,101 @@
+import type { TouchPanelInputEvent } from 'input-event'
+import Time from 'time'
+import Timer from 'timer'
+import TouchPanel from 'touch-panel'
+import { assert, equal } from 'testing/assert'
+
+class FakeTouchPanelDriver {
+  static current: FakeTouchPanelDriver | undefined
+
+  closed = false
+  sampleCount = 0
+  #samples: number[][] = []
+
+  constructor(_options: unknown) {
+    FakeTouchPanelDriver.current = this
+  }
+
+  sample(): number[] {
+    this.sampleCount += 1
+    return this.#samples.shift() ?? []
+  }
+
+  queue(...samples: number[][]): void {
+    this.#samples.push(...samples)
+  }
+
+  close(): void {
+    this.closed = true
+  }
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => Timer.set(() => resolve(), milliseconds))
+}
+
+async function waitForSampleCount(driver: FakeTouchPanelDriver, count: number): Promise<void> {
+  const deadline = Time.ticks + 500
+  while (driver.sampleCount < count) {
+    assert(Time.ticks < deadline, `TouchPanel should poll at least ${count} samples`)
+    await wait(5)
+  }
+}
+
+function assertPressAndRelease(events: TouchPanelInputEvent[], label: string): void {
+  equal(events.length, 2, `${label} should receive two events`)
+  equal(events[0].gesture, 'press', `${label} should receive press first`)
+  equal(events[1].gesture, 'release', `${label} should receive release second`)
+}
+
+async function runTest(): Promise<void> {
+  FakeTouchPanelDriver.current = undefined
+  const touchPanel = new TouchPanel(FakeTouchPanelDriver, { interval: 10 })
+  const driver = FakeTouchPanelDriver.current
+  assert(driver, 'TouchPanel should instantiate its driver')
+
+  const legacyEvents: TouchPanelInputEvent[] = []
+  const subscriberEvents: TouchPanelInputEvent[] = []
+  const survivingEvents: TouchPanelInputEvent[] = []
+  touchPanel.onEvent = (event) => legacyEvents.push(event)
+  touchPanel.subscribe(() => {
+    throw new Error('injected listener failure')
+  })
+  const unsubscribe = touchPanel.subscribe((event) => subscriberEvents.push(event))
+  touchPanel.subscribe((event) => survivingEvents.push(event))
+
+  driver.queue([0, 1, 0], [0, 0, 0])
+  touchPanel.start()
+  await waitForSampleCount(driver, 2)
+
+  assertPressAndRelease(legacyEvents, 'legacy onEvent')
+  assertPressAndRelease(subscriberEvents, 'subscriber')
+  assertPressAndRelease(survivingEvents, 'surviving subscriber')
+  const tap = subscriberEvents[1].tap
+  assert(tap, 'release should include tap details')
+  assert(tap.durationMs >= 0 && tap.durationMs <= 300, 'tap duration should remain inside the recognizer limit')
+  equal(tap.maxMovement, 0, 'stable tap should not report movement')
+  equal(tap.position, 0, 'center tap should report center position')
+
+  unsubscribe()
+  driver.queue([1, 0, 0], [0, 0, 0])
+  await waitForSampleCount(driver, 4)
+
+  equal(subscriberEvents.length, 2, 'unsubscribe should stop only the selected listener')
+  equal(legacyEvents.length, 4, 'legacy onEvent should remain compatible')
+  equal(survivingEvents.length, 4, 'another subscriber should continue receiving events')
+
+  touchPanel.close()
+  const samplesAfterClose = driver.sampleCount
+  driver.queue([0, 1, 0])
+  await wait(30)
+  equal(driver.sampleCount, samplesAfterClose, 'close should stop polling')
+  equal(survivingEvents.length, 4, 'close should stop sampling and clear subscribers')
+  equal(driver.closed, true, 'close should release the touch panel driver')
+
+  trace('ok\n')
+}
+
+runTest().catch((error) => {
+  trace(`TouchPanel test failed: ${String(error)}\n`)
+  throw error
+})

--- a/firmware/host/modules/input/__tests__/touch.test.ts
+++ b/firmware/host/modules/input/__tests__/touch.test.ts
@@ -4,11 +4,16 @@ import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 import { writeAliasPackage } from '../../testing/node-alias-package.js'
-import type { TouchInputEvent } from '../input-event.js'
+import type { TouchInputEvent, TouchPanelInputEvent } from '../input-event.js'
 
 type FakeTimer = {
   advance(milliseconds: number): void
   reset(): void
+}
+
+type FakeTime = {
+  reset(): void
+  setTicks(ticks: number): void
 }
 
 type TouchSample = Array<{ id: number; x: number; y: number }>
@@ -50,9 +55,33 @@ class FakeTouchDriver {
   }
 }
 
+class FakeTouchPanelDriver {
+  static current: FakeTouchPanelDriver | undefined
+
+  closed = false
+  #samples: number[][] = []
+
+  constructor(_options: unknown) {
+    FakeTouchPanelDriver.current = this
+  }
+
+  sample(): number[] {
+    return this.#samples.shift() ?? []
+  }
+
+  queue(sample: number[]): void {
+    this.#samples.push(sample)
+  }
+
+  close(): void {
+    this.closed = true
+  }
+}
+
 function installBareSpecifierPackages(): void {
   const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
   writeAliasPackage(modulesRoot, 'input-event', resolve(modulesRoot, 'input/input-event.js'))
+  writeAliasPackage(modulesRoot, 'touch-panel-gesture', resolve(modulesRoot, 'input/touch-panel-gesture.js'))
   writeAliasPackage(modulesRoot, 'timer', resolve(modulesRoot, 'testing/fakes/timer.js'), { hasDefaultExport: true })
   writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), { hasDefaultExport: true })
 }
@@ -75,6 +104,24 @@ async function createTouch(options: TouchOptions, driverOptions: { interrupt?: b
 
   assert.ok(FakeTouchDriver.current)
   return { driver: FakeTouchDriver.current, events, fakeTimer }
+}
+
+async function createTouchPanel() {
+  installBareSpecifierPackages()
+  const [{ default: TouchPanel }, { default: fakeTimer }, { default: fakeTime }] = await Promise.all([
+    import('../touch-panel.js'),
+    import('timer') as Promise<{ default: FakeTimer }>,
+    import('time') as Promise<{ default: FakeTime }>,
+  ])
+
+  fakeTimer.reset()
+  fakeTime.reset()
+  FakeTouchPanelDriver.current = undefined
+  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = () => {}
+
+  const touchPanel = new TouchPanel(FakeTouchPanelDriver, { interval: 10 })
+  assert.ok(FakeTouchPanelDriver.current)
+  return { driver: FakeTouchPanelDriver.current, fakeTime, fakeTimer, touchPanel }
 }
 
 test('Touch emits ended immediately when release debounce is disabled', async () => {
@@ -159,4 +206,62 @@ test('Touch switches ECMA-419 polling from idle to active interval while a point
   )
   fakeTimer.advance(1)
   assert.equal(events.at(-1)?.phase, 'ended')
+})
+
+test('TouchPanel fans out tap events without replacing petting subscribers', async () => {
+  const { driver, fakeTime, fakeTimer, touchPanel } = await createTouchPanel()
+  const legacyEvents: TouchPanelInputEvent[] = []
+  const subscriberEvents: TouchPanelInputEvent[] = []
+  const survivingEvents: TouchPanelInputEvent[] = []
+  touchPanel.onEvent = (event) => legacyEvents.push(event)
+  touchPanel.subscribe(() => {
+    throw new Error('injected listener failure')
+  })
+  const unsubscribe = touchPanel.subscribe((event) => subscriberEvents.push(event))
+  touchPanel.subscribe((event) => survivingEvents.push(event))
+  touchPanel.start()
+
+  driver.queue([0, 1, 0])
+  fakeTime.setTicks(100)
+  fakeTimer.advance(10)
+  driver.queue([0, 0, 0])
+  fakeTime.setTicks(250)
+  fakeTimer.advance(10)
+
+  assert.deepEqual(
+    legacyEvents.map((event) => event.gesture),
+    ['press', 'release'],
+  )
+  assert.deepEqual(
+    subscriberEvents.map((event) => event.gesture),
+    ['press', 'release'],
+  )
+  assert.deepEqual(
+    survivingEvents.map((event) => event.gesture),
+    ['press', 'release'],
+  )
+  assert.deepEqual(subscriberEvents.at(-1)?.tap, {
+    durationMs: 150,
+    maxMovement: 0,
+    position: 0,
+  })
+
+  unsubscribe()
+  driver.queue([1, 0, 0])
+  fakeTime.setTicks(300)
+  fakeTimer.advance(10)
+  driver.queue([0, 0, 0])
+  fakeTime.setTicks(350)
+  fakeTimer.advance(10)
+
+  assert.equal(subscriberEvents.length, 2, 'unsubscribe should stop only the selected listener')
+  assert.equal(legacyEvents.length, 4, 'legacy onEvent should remain compatible')
+  assert.equal(survivingEvents.length, 4, 'another subscriber should continue receiving events')
+
+  touchPanel.close()
+  driver.queue([0, 1, 0])
+  fakeTime.setTicks(400)
+  fakeTimer.advance(10)
+  assert.equal(survivingEvents.length, 4, 'close should stop sampling and clear subscribers')
+  assert.equal(driver.closed, true, 'close should release the touch panel driver')
 })

--- a/firmware/host/modules/input/__tests__/touch.test.ts
+++ b/firmware/host/modules/input/__tests__/touch.test.ts
@@ -4,16 +4,11 @@ import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
 import { writeAliasPackage } from '../../testing/node-alias-package.js'
-import type { TouchInputEvent, TouchPanelInputEvent } from '../input-event.js'
+import type { TouchInputEvent } from '../input-event.js'
 
 type FakeTimer = {
   advance(milliseconds: number): void
   reset(): void
-}
-
-type FakeTime = {
-  reset(): void
-  setTicks(ticks: number): void
 }
 
 type TouchSample = Array<{ id: number; x: number; y: number }>
@@ -55,33 +50,9 @@ class FakeTouchDriver {
   }
 }
 
-class FakeTouchPanelDriver {
-  static current: FakeTouchPanelDriver | undefined
-
-  closed = false
-  #samples: number[][] = []
-
-  constructor(_options: unknown) {
-    FakeTouchPanelDriver.current = this
-  }
-
-  sample(): number[] {
-    return this.#samples.shift() ?? []
-  }
-
-  queue(sample: number[]): void {
-    this.#samples.push(sample)
-  }
-
-  close(): void {
-    this.closed = true
-  }
-}
-
 function installBareSpecifierPackages(): void {
   const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
   writeAliasPackage(modulesRoot, 'input-event', resolve(modulesRoot, 'input/input-event.js'))
-  writeAliasPackage(modulesRoot, 'touch-panel-gesture', resolve(modulesRoot, 'input/touch-panel-gesture.js'))
   writeAliasPackage(modulesRoot, 'timer', resolve(modulesRoot, 'testing/fakes/timer.js'), { hasDefaultExport: true })
   writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), { hasDefaultExport: true })
 }
@@ -104,24 +75,6 @@ async function createTouch(options: TouchOptions, driverOptions: { interrupt?: b
 
   assert.ok(FakeTouchDriver.current)
   return { driver: FakeTouchDriver.current, events, fakeTimer }
-}
-
-async function createTouchPanel() {
-  installBareSpecifierPackages()
-  const [{ default: TouchPanel }, { default: fakeTimer }, { default: fakeTime }] = await Promise.all([
-    import('../touch-panel.js'),
-    import('timer') as Promise<{ default: FakeTimer }>,
-    import('time') as Promise<{ default: FakeTime }>,
-  ])
-
-  fakeTimer.reset()
-  fakeTime.reset()
-  FakeTouchPanelDriver.current = undefined
-  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = () => {}
-
-  const touchPanel = new TouchPanel(FakeTouchPanelDriver, { interval: 10 })
-  assert.ok(FakeTouchPanelDriver.current)
-  return { driver: FakeTouchPanelDriver.current, fakeTime, fakeTimer, touchPanel }
 }
 
 test('Touch emits ended immediately when release debounce is disabled', async () => {
@@ -206,62 +159,4 @@ test('Touch switches ECMA-419 polling from idle to active interval while a point
   )
   fakeTimer.advance(1)
   assert.equal(events.at(-1)?.phase, 'ended')
-})
-
-test('TouchPanel fans out tap events without replacing petting subscribers', async () => {
-  const { driver, fakeTime, fakeTimer, touchPanel } = await createTouchPanel()
-  const legacyEvents: TouchPanelInputEvent[] = []
-  const subscriberEvents: TouchPanelInputEvent[] = []
-  const survivingEvents: TouchPanelInputEvent[] = []
-  touchPanel.onEvent = (event) => legacyEvents.push(event)
-  touchPanel.subscribe(() => {
-    throw new Error('injected listener failure')
-  })
-  const unsubscribe = touchPanel.subscribe((event) => subscriberEvents.push(event))
-  touchPanel.subscribe((event) => survivingEvents.push(event))
-  touchPanel.start()
-
-  driver.queue([0, 1, 0])
-  fakeTime.setTicks(100)
-  fakeTimer.advance(10)
-  driver.queue([0, 0, 0])
-  fakeTime.setTicks(250)
-  fakeTimer.advance(10)
-
-  assert.deepEqual(
-    legacyEvents.map((event) => event.gesture),
-    ['press', 'release'],
-  )
-  assert.deepEqual(
-    subscriberEvents.map((event) => event.gesture),
-    ['press', 'release'],
-  )
-  assert.deepEqual(
-    survivingEvents.map((event) => event.gesture),
-    ['press', 'release'],
-  )
-  assert.deepEqual(subscriberEvents.at(-1)?.tap, {
-    durationMs: 150,
-    maxMovement: 0,
-    position: 0,
-  })
-
-  unsubscribe()
-  driver.queue([1, 0, 0])
-  fakeTime.setTicks(300)
-  fakeTimer.advance(10)
-  driver.queue([0, 0, 0])
-  fakeTime.setTicks(350)
-  fakeTimer.advance(10)
-
-  assert.equal(subscriberEvents.length, 2, 'unsubscribe should stop only the selected listener')
-  assert.equal(legacyEvents.length, 4, 'legacy onEvent should remain compatible')
-  assert.equal(survivingEvents.length, 4, 'another subscriber should continue receiving events')
-
-  touchPanel.close()
-  driver.queue([0, 1, 0])
-  fakeTime.setTicks(400)
-  fakeTimer.advance(10)
-  assert.equal(survivingEvents.length, 4, 'close should stop sampling and clear subscribers')
-  assert.equal(driver.closed, true, 'close should release the touch panel driver')
 })

--- a/firmware/host/modules/input/input-event.ts
+++ b/firmware/host/modules/input/input-event.ts
@@ -1,5 +1,5 @@
 import type { MotionType } from 'imu-motion'
-import type { TouchPanelGestureType } from 'touch-panel-gesture'
+import type { TouchPanelGestureType, TouchPanelTap } from 'touch-panel-gesture'
 
 export type ButtonInputEvent = {
   kind: 'button'
@@ -23,6 +23,7 @@ export type TouchPanelInputEvent = {
   position: number
   intensity: number
   ticks: number
+  tap?: TouchPanelTap
 }
 
 export type IMUInputEvent = {
@@ -56,8 +57,9 @@ export function createTouchPanelInputEvent(
   position: number,
   intensity: number,
   ticks: number,
+  tap?: TouchPanelTap,
 ): TouchPanelInputEvent {
-  return { kind: 'touch-panel', gesture, position, intensity, ticks }
+  return { kind: 'touch-panel', gesture, position, intensity, ticks, ...(tap ? { tap } : {}) }
 }
 
 export function createIMUInputEvent(motion: MotionType, ticks: number): IMUInputEvent {

--- a/firmware/host/modules/input/touch-panel-gesture.test.ts
+++ b/firmware/host/modules/input/touch-panel-gesture.test.ts
@@ -20,6 +20,34 @@ test('recognizes press and release from Si12T intensity samples', () => {
   )
 })
 
+test('marks a short stable release as a tap', () => {
+  const recognizer = new GestureRecognizer()
+
+  assert.equal(recognizer.update([0, 1, 0], 100)?.type, 'press')
+  assert.equal(recognizer.update([0, 6, 1], 250), undefined)
+  assert.deepEqual(recognizer.update([0, 0, 0], 400), {
+    type: 'release',
+    sample: [0, 0, 0],
+    ticks: 400,
+    tap: {
+      durationMs: 300,
+      maxMovement: 14,
+      position: 0,
+    },
+  })
+})
+
+test('does not mark long or drifting touches as taps', () => {
+  const longPress = new GestureRecognizer()
+  longPress.update([0, 1, 0], 0)
+  assert.equal(longPress.update([0, 0, 0], 301)?.tap, undefined)
+
+  const driftingPress = new GestureRecognizer()
+  driftingPress.update([0, 1, 0], 0)
+  driftingPress.update([0, 5, 1], 100)
+  assert.equal(driftingPress.update([0, 0, 0], 200)?.tap, undefined)
+})
+
 test('recognizes forward swipe when weighted position moves past positive threshold', () => {
   assert.deepEqual(
     run([
@@ -55,6 +83,14 @@ test('does not emit repeated swipe gestures while still touching', () => {
     ]),
     ['press', 'forwardSwipe', 'release'],
   )
+})
+
+test('does not mark a completed swipe release as a tap', () => {
+  const recognizer = new GestureRecognizer()
+  recognizer.update([1, 0, 0], 0)
+  recognizer.update([0, 0, 1], 50)
+
+  assert.equal(recognizer.update([0, 0, 0], 100)?.tap, undefined)
 })
 
 test('uses weighted intensity for position calculation', () => {

--- a/firmware/host/modules/input/touch-panel-gesture.test.ts
+++ b/firmware/host/modules/input/touch-panel-gesture.test.ts
@@ -72,6 +72,28 @@ test('recognizes backward swipe when weighted position moves past negative thres
   )
 })
 
+test('does not treat a 50-point position wobble as a swipe', () => {
+  assert.deepEqual(
+    run([
+      [0, 1, 0],
+      [0, 1, 1],
+      [0, 0, 0],
+    ]),
+    ['press', 'release'],
+  )
+})
+
+test('recognizes a deliberate swipe beyond the 60-point threshold', () => {
+  assert.deepEqual(
+    run([
+      [0, 1, 0],
+      [0, 1, 2],
+      [0, 0, 0],
+    ]),
+    ['press', 'forwardSwipe', 'release'],
+  )
+})
+
 test('does not emit repeated swipe gestures while still touching', () => {
   assert.deepEqual(
     run([

--- a/firmware/host/modules/input/touch-panel-gesture.ts
+++ b/firmware/host/modules/input/touch-panel-gesture.ts
@@ -2,15 +2,24 @@ export type TouchPanelSample = number[]
 
 export type TouchPanelGestureType = 'press' | 'release' | 'forwardSwipe' | 'backwardSwipe'
 
+export type TouchPanelTap = {
+  durationMs: number
+  maxMovement: number
+  position: number
+}
+
 export type TouchPanelGesture = {
   type: TouchPanelGestureType
   sample: TouchPanelSample
   ticks: number
+  tap?: TouchPanelTap
 }
 
 export type TouchPanelGestureRecognizerOptions = {
   touchThreshold?: number
   swipeThreshold?: number
+  tapMaxDuration?: number
+  tapMaxMovement?: number
 }
 
 const TouchState = Object.freeze({
@@ -24,17 +33,25 @@ type TouchState = (typeof TouchState)[keyof typeof TouchState]
 export class GestureRecognizer {
   #state: TouchState = TouchState.IDLE
   #initialPosition = 0
+  #initialTicks = 0
+  #maxMovement = 0
   #touchThreshold: number
   #swipeThreshold: number
+  #tapMaxDuration: number
+  #tapMaxMovement: number
 
   constructor(options: TouchPanelGestureRecognizerOptions = {}) {
     this.#touchThreshold = options.touchThreshold ?? 1
     this.#swipeThreshold = options.swipeThreshold ?? 40
+    this.#tapMaxDuration = options.tapMaxDuration ?? 300
+    this.#tapMaxMovement = options.tapMaxMovement ?? 15
   }
 
   reset(): void {
     this.#state = TouchState.IDLE
     this.#initialPosition = 0
+    this.#initialTicks = 0
+    this.#maxMovement = 0
   }
 
   update(sample: TouchPanelSample, ticks: number): TouchPanelGesture | undefined {
@@ -43,6 +60,8 @@ export class GestureRecognizer {
         if (this.#isTouched(sample)) {
           this.#state = TouchState.TOUCHED
           this.#initialPosition = this.getPosition(sample)
+          this.#initialTicks = ticks
+          this.#maxMovement = 0
           return { type: 'press', sample: [...sample], ticks }
         }
         break
@@ -50,11 +69,21 @@ export class GestureRecognizer {
       case TouchState.TOUCHED:
         if (!this.#isTouched(sample)) {
           this.#state = TouchState.IDLE
-          return { type: 'release', sample: [...sample], ticks }
+          const durationMs = Math.max(0, ticks - this.#initialTicks)
+          const tap =
+            durationMs <= this.#tapMaxDuration && this.#maxMovement <= this.#tapMaxMovement
+              ? {
+                  durationMs,
+                  maxMovement: this.#maxMovement,
+                  position: this.#initialPosition,
+                }
+              : undefined
+          return { type: 'release', sample: [...sample], ticks, ...(tap ? { tap } : {}) }
         }
 
         {
           const delta = this.getPosition(sample) - this.#initialPosition
+          this.#maxMovement = Math.max(this.#maxMovement, Math.abs(delta))
           if (delta > this.#swipeThreshold) {
             this.#state = TouchState.SWIPING
             return { type: 'forwardSwipe', sample: [...sample], ticks }

--- a/firmware/host/modules/input/touch-panel-gesture.ts
+++ b/firmware/host/modules/input/touch-panel-gesture.ts
@@ -42,7 +42,7 @@ export class GestureRecognizer {
 
   constructor(options: TouchPanelGestureRecognizerOptions = {}) {
     this.#touchThreshold = options.touchThreshold ?? 1
-    this.#swipeThreshold = options.swipeThreshold ?? 40
+    this.#swipeThreshold = options.swipeThreshold ?? 60
     this.#tapMaxDuration = options.tapMaxDuration ?? 300
     this.#tapMaxMovement = options.tapMaxMovement ?? 15
   }

--- a/firmware/host/modules/input/touch-panel.ts
+++ b/firmware/host/modules/input/touch-panel.ts
@@ -7,6 +7,7 @@ import {
   type TouchPanelGestureRecognizerOptions,
   type TouchPanelGestureType,
   type TouchPanelSample,
+  type TouchPanelTap,
 } from 'touch-panel-gesture'
 
 type TouchPanelDriver = {
@@ -26,12 +27,13 @@ type TouchPanelOptions = TouchPanelGestureRecognizerOptions & {
 
 export default class TouchPanel {
   #driver: TouchPanelDriver
-  #timer: Timer | undefined
+  #timer: ReturnType<typeof Timer.repeat> | undefined
   #recognizer: GestureRecognizer
   #interval: number
+  #listeners = new Set<(event: TouchPanelInputEvent) => void>()
   #sampleErrorReported = false
   #lastSample: TouchPanelSample = []
-  onEvent: (event: TouchPanelInputEvent) => void
+  onEvent?: (event: TouchPanelInputEvent) => void
 
   constructor(TouchPanelConstructor: TouchPanelConstructor, options: TouchPanelOptions = {}) {
     trace('[TouchPanel] constructor: instantiating\n')
@@ -61,6 +63,11 @@ export default class TouchPanel {
     this.#driver.configure?.(options)
   }
 
+  subscribe(listener: (event: TouchPanelInputEvent) => void): () => void {
+    this.#listeners.add(listener)
+    return () => this.#listeners.delete(listener)
+  }
+
   start(): void {
     if (this.#timer) return
     trace(`[TouchPanel] start interval=${this.#interval}ms\n`)
@@ -81,7 +88,9 @@ export default class TouchPanel {
       const gesture = this.#recognizer.update(sample, ticks)
       if (gesture) {
         const intensity = Math.max(sample[0] ?? 0, sample[1] ?? 0, sample[2] ?? 0)
-        this.onEvent?.(createTouchPanelInputEvent(gesture.type, this.#recognizer.getPosition(sample), intensity, ticks))
+        this.#emit(
+          createTouchPanelInputEvent(gesture.type, this.#recognizer.getPosition(sample), intensity, ticks, gesture.tap),
+        )
       }
     }, this.#interval)
   }
@@ -96,11 +105,29 @@ export default class TouchPanel {
 
   close(): void {
     this.stop()
+    this.#listeners.clear()
     this.#driver.close?.()
+  }
+
+  #emit(event: TouchPanelInputEvent): void {
+    const listeners = this.onEvent ? [this.onEvent, ...this.#listeners] : [...this.#listeners]
+    for (const listener of listeners) {
+      try {
+        listener(event)
+      } catch (error) {
+        trace(`[TouchPanel] listener error ${errorMessage(error)}\n`)
+      }
+    }
   }
 }
 
-export { GestureRecognizer, type TouchPanelGesture, type TouchPanelGestureType, type TouchPanelSample }
+export {
+  GestureRecognizer,
+  type TouchPanelGesture,
+  type TouchPanelGestureType,
+  type TouchPanelSample,
+  type TouchPanelTap,
+}
 
 function errorMessage(error: unknown): string {
   if (error && typeof error === 'object' && 'message' in error) {

--- a/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
+++ b/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
@@ -44,6 +44,7 @@ type StatusBarBehavior = {
 type StatusBarContent = {
   content(name: string): unknown
   behavior?: StatusBarBehavior
+  skin?: unknown
   visible?: boolean
 }
 
@@ -56,6 +57,7 @@ type StatusIcon = {
 type StatusIndicator = {
   active?: boolean
   visible?: boolean
+  x?: number
 }
 
 type LevelTrack = {
@@ -118,6 +120,7 @@ const title = bar.content('title') as BarTitle
 const clock = bar.content('clock') as ClockLabel
 const battery = bar.content('battery') as BatteryPort
 const behavior = bar.behavior as StatusBarBehavior
+const faceChromeSkin = bar.skin
 
 clock.behavior?.onDisplaying?.(clock)
 battery.behavior?.onDisplaying?.(battery)
@@ -144,7 +147,11 @@ battery.behavior?.onDraw?.({
 })
 assert(batteryDrawBounds.width > (battery.width ?? 0) * 0.9, 'battery drawing should fill the double-width surface')
 assert(batteryDrawBounds.height > (battery.height ?? 0) * 0.8, 'battery drawing should fill the double-height surface')
-assert((statusIcon.x ?? 0) > (battery.x ?? 0) + (battery.width ?? 0), 'chat status should move right of battery')
+equal(statusIcon.x, 8, 'persistent microphone status should use the natural top-left position')
+assert(
+  (statusIndicator.x ?? 0) > (battery.x ?? 0) + (battery.width ?? 0),
+  'transient connection status should remain beside the AppBar battery',
+)
 equal(formatAppBarTime(new Date(0)), '--:--', 'unset system time should use a placeholder')
 equal(batteryLevelToSegments(0), 0, 'empty battery should draw no cells')
 equal(batteryLevelToSegments(25), 1, 'quarter battery should draw one cell')
@@ -192,6 +199,7 @@ assert(battery.visible === true, 'battery status should recover after a later va
 
 behavior.onFinished?.(bar)
 assert(bar.visible === false, 'the reveal timer should hide the entire AppBar')
+assert(bar.skin !== faceChromeSkin, 'hidden face chrome should restore the transparent status layer')
 assert(menuButton.visible === false, 'menu button should hide with the AppBar')
 assert(menuButton.active === false, 'hidden menu button should not intercept touches')
 assert(appsButton.visible === false, 'apps button should hide with the menu button')
@@ -205,6 +213,7 @@ behavior.onMiniAppAvailability?.(bar, true)
 assert(appsButton.visible === false, 'availability changes should not bypass the hidden AppBar state')
 behavior.onAppBarReveal?.(bar)
 assert(bar.visible === true, 'an explicit reveal should restore the entire AppBar')
+assert(bar.skin === faceChromeSkin, 'the visible face AppBar should use an opaque background')
 assert(menuButton.visible === true, 'menu button should be revealed again on request')
 assert(menuButton.active === true, 'revealed menu button should accept touches')
 assert(appsButton.visible === true, 'apps button should be revealed with the menu button')
@@ -220,12 +229,12 @@ assert(statusIndicator.active === false, 'connecting indicator should never inte
 assert(statusIcon.visible === false, 'status icon should be hidden while connecting')
 
 behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
-assert(levelTrack.visible === true, 'level track should be visible while user is speaking')
-assert(statusIcon.visible === true, 'status icon should be visible while user is speaking')
-equal(statusIcon.state, 0, 'user speaking should use microphone input icon state')
+assert(levelTrack.visible === false, 'visible AppBar should hide the input level beside its battery')
+assert(statusIcon.visible === false, 'visible AppBar should hide the microphone beside its battery')
 
 behavior.onFinished?.(bar)
 assert(bar.visible === true, 'user input should keep the microphone area visible after the AppBar timeout')
+assert(bar.skin !== faceChromeSkin, 'persistent microphone status should not retain the AppBar background')
 assert(menuButton.visible === false, 'persistent microphone status should not keep face actions visible')
 assert(clock.visible === false, 'persistent microphone status should not keep the clock visible')
 assert(battery.visible === false, 'persistent microphone status should not keep battery status visible')
@@ -242,16 +251,15 @@ assert(levelTrack.visible === false, 'external connection indicator should take 
 assert(statusIcon.visible === false, 'external connection indicator should take priority over the status icon')
 behavior.onConnectionIndicator?.(bar, false)
 assert(statusIndicator.visible === false, 'external connection indicator should hide when connection is ready')
-assert(levelTrack.visible === true, 'level track should return after the external connection is ready')
-assert(statusIcon.visible === true, 'status icon should return after the external connection is ready')
+assert(levelTrack.visible === false, 'visible AppBar should keep the level track hidden after connection')
+assert(statusIcon.visible === false, 'visible AppBar should keep the microphone hidden after connection')
 
 behavior.onChatInputLevel?.(bar, 1000)
 equal(levelFill.height, 8, 'half input level should fill half the track')
 
 behavior.onChatState?.(bar, ChatStatusBarState.LISTENING)
 assert(levelTrack.visible === false, 'level track should be hidden while user is listening')
-assert(statusIcon.visible === true, 'status icon should be visible while user is listening')
-equal(statusIcon.state, 1, 'user listening should use output icon state')
+assert(statusIcon.visible === false, 'visible AppBar should not add chat status beside its battery')
 
 const normalFillSkin = levelFill.skin
 behavior.onChatState?.(bar, ChatStatusBarState.FAILED, 'boom')

--- a/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
+++ b/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
@@ -224,6 +224,18 @@ assert(levelTrack.visible === true, 'level track should be visible while user is
 assert(statusIcon.visible === true, 'status icon should be visible while user is speaking')
 equal(statusIcon.state, 0, 'user speaking should use microphone input icon state')
 
+behavior.onFinished?.(bar)
+assert(bar.visible === true, 'user input should keep the microphone area visible after the AppBar timeout')
+assert(menuButton.visible === false, 'persistent microphone status should not keep face actions visible')
+assert(clock.visible === false, 'persistent microphone status should not keep the clock visible')
+assert(battery.visible === false, 'persistent microphone status should not keep battery status visible')
+assert(levelTrack.visible === true, 'input level should remain visible after the AppBar timeout')
+assert(statusIcon.visible === true, 'microphone icon should remain visible after the AppBar timeout')
+behavior.onChatState?.(bar, ChatStatusBarState.WAITING)
+assert(bar.visible === false, 'leaving user input should hide a previously timed-out AppBar')
+behavior.onAppBarReveal?.(bar)
+behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
+
 behavior.onConnectionIndicator?.(bar, true)
 assert(statusIndicator.visible === true, 'external connection indicator should be visible')
 assert(levelTrack.visible === false, 'external connection indicator should take priority over the level track')

--- a/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
+++ b/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
@@ -364,13 +364,16 @@ class ChatStatusBarBehavior extends Behavior {
     if (!this.#levelTrack || !this.#levelFill || !this.#statusIcon || !this.#indicator) return
     const faceMode = this.#mode.kind === 'face'
     const faceChromeVisible = faceMode && this.#faceBarVisible
-    // ChatAudioIO.SPEAKING means user input; LISTENING means assistant output.
+    // ChatAudioIO.SPEAKING means user input.
     const isUserSpeaking = this.#state === ChatStatusBarState.SPEAKING
-    const isUserListening = this.#state === ChatStatusBarState.LISTENING
     const isConnecting = this.#state === ChatStatusBarState.CONNECTING || this.#connectionPending
     const persistentInputVisible = faceMode && !faceChromeVisible && isUserSpeaking && !isConnecting
     const faceStatusVisible = faceChromeVisible || persistentInputVisible
-    if (this.#container) this.#container.visible = !faceMode || faceStatusVisible
+    const skins = getSkins()
+    if (this.#container) {
+      this.#container.visible = !faceMode || faceStatusVisible
+      this.#container.skin = !faceMode || faceChromeVisible ? skins.chrome : skins.bar
+    }
     const clockBehavior = this.#clock?.behavior as ClockBehaviorContract | undefined
     if (this.#clock) clockBehavior?.onVisibilityChanged(this.#clock, faceChromeVisible)
     const batteryBehavior = this.#battery?.behavior as BatteryBehaviorContract | undefined
@@ -382,9 +385,12 @@ class ChatStatusBarBehavior extends Behavior {
       this.#indicator.stop()
       return
     }
-    this.#levelTrack.visible = !isConnecting && isUserSpeaking
-    this.#statusIcon.visible = !isConnecting && (isUserSpeaking || (faceChromeVisible && isUserListening))
-    this.#statusIcon.state = isUserListening ? 1 : 0
+    // The face AppBar owns the top-left system area while it is visible. Once
+    // its four-second reveal ends, input status replaces it at the natural
+    // left edge instead of remaining shifted beside an absent battery icon.
+    this.#levelTrack.visible = persistentInputVisible
+    this.#statusIcon.visible = persistentInputVisible
+    this.#statusIcon.state = 0
     this.#indicator.visible = faceChromeVisible && isConnecting
     if (this.#indicator.visible) {
       this.#indicator.interval = 250
@@ -394,7 +400,6 @@ class ChatStatusBarBehavior extends Behavior {
       this.#indicator.stop()
       this.#indicator.variant = 0
     }
-    const skins = getSkins()
     this.#levelFill.skin = this.#state === ChatStatusBarState.FAILED ? skins.errorFill : skins.levelFill
     this.updateLevel()
   }
@@ -434,7 +439,8 @@ class ChatStatusBarBehavior extends Behavior {
 export const ChatStatusBar = Container.template((options: ChatStatusBarOptions = {}) => {
   const skins = getSkins()
   const styles = uiStyles()
-  const statusIconLeft = options.readBatteryLevel ? batteryStatusIconLeft : defaultIconLeft
+  const statusIconLeft = defaultIconLeft
+  const indicatorLeft = options.readBatteryLevel ? batteryStatusIconLeft : defaultIconLeft
   const levelLeft = statusIconLeft + iconSize + 4
   return {
     name: 'ChatStatusBar',
@@ -508,7 +514,7 @@ export const ChatStatusBar = Container.template((options: ChatStatusBarOptions =
       }),
       new Content(null, {
         name: 'statusIndicator',
-        left: statusIconLeft,
+        left: indicatorLeft,
         top: iconTop,
         width: iconSize,
         height: iconSize,

--- a/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
+++ b/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
@@ -265,6 +265,7 @@ class BatteryBehavior extends Behavior implements BatteryBehaviorContract {
 }
 
 class ChatStatusBarBehavior extends Behavior {
+  #container?: Container
   #mode: AppBarMode = { kind: 'face' }
   #state: ChatStatusBarState = ChatStatusBarState.DISCONNECTED
   #connectionPending = false
@@ -283,6 +284,7 @@ class ChatStatusBarBehavior extends Behavior {
   #miniAppsAvailable = false
 
   onCreate(container: Container) {
+    this.#container = container
     this.#statusIcon = container.content('statusIcon') as Content
     this.#indicator = container.content('statusIndicator') as Content
     this.#levelTrack = container.content('levelTrack') as Container
@@ -293,7 +295,7 @@ class ChatStatusBarBehavior extends Behavior {
     this.#title = container.content('title') as Label
     this.#clock = container.content('clock') as Label
     this.#battery = container.content('battery') as PiuPort
-    this.setFaceBarVisible(container, true)
+    this.setFaceBarVisible(true)
   }
 
   onDisplaying(container: Container) {
@@ -306,7 +308,7 @@ class ChatStatusBarBehavior extends Behavior {
 
   onFinished(container: Container) {
     if (this.#mode.kind !== 'face') return
-    this.setFaceBarVisible(container, false)
+    this.setFaceBarVisible(false)
     container.stop()
   }
 
@@ -361,11 +363,18 @@ class ChatStatusBarBehavior extends Behavior {
   updateUI() {
     if (!this.#levelTrack || !this.#levelFill || !this.#statusIcon || !this.#indicator) return
     const faceMode = this.#mode.kind === 'face'
-    const faceStatusVisible = faceMode && this.#faceBarVisible
+    const faceChromeVisible = faceMode && this.#faceBarVisible
+    // ChatAudioIO.SPEAKING means user input; LISTENING means assistant output.
+    const isUserSpeaking = this.#state === ChatStatusBarState.SPEAKING
+    const isUserListening = this.#state === ChatStatusBarState.LISTENING
+    const isConnecting = this.#state === ChatStatusBarState.CONNECTING || this.#connectionPending
+    const persistentInputVisible = faceMode && !faceChromeVisible && isUserSpeaking && !isConnecting
+    const faceStatusVisible = faceChromeVisible || persistentInputVisible
+    if (this.#container) this.#container.visible = !faceMode || faceStatusVisible
     const clockBehavior = this.#clock?.behavior as ClockBehaviorContract | undefined
-    if (this.#clock) clockBehavior?.onVisibilityChanged(this.#clock, faceStatusVisible)
+    if (this.#clock) clockBehavior?.onVisibilityChanged(this.#clock, faceChromeVisible)
     const batteryBehavior = this.#battery?.behavior as BatteryBehaviorContract | undefined
-    if (this.#battery) batteryBehavior?.onVisibilityChanged(this.#battery, faceStatusVisible)
+    if (this.#battery) batteryBehavior?.onVisibilityChanged(this.#battery, faceChromeVisible)
     if (!faceStatusVisible) {
       this.#levelTrack.visible = false
       this.#statusIcon.visible = false
@@ -373,15 +382,11 @@ class ChatStatusBarBehavior extends Behavior {
       this.#indicator.stop()
       return
     }
-    // ChatAudioIO.SPEAKING means user input; LISTENING means assistant output.
-    const isUserSpeaking = this.#state === ChatStatusBarState.SPEAKING
-    const isUserListening = this.#state === ChatStatusBarState.LISTENING
-    const isConnecting = this.#state === ChatStatusBarState.CONNECTING || this.#connectionPending
     this.#levelTrack.visible = !isConnecting && isUserSpeaking
-    this.#statusIcon.visible = !isConnecting && (isUserSpeaking || isUserListening)
+    this.#statusIcon.visible = !isConnecting && (isUserSpeaking || (faceChromeVisible && isUserListening))
     this.#statusIcon.state = isUserListening ? 1 : 0
-    this.#indicator.visible = isConnecting
-    if (isConnecting) {
+    this.#indicator.visible = faceChromeVisible && isConnecting
+    if (this.#indicator.visible) {
       this.#indicator.interval = 250
       this.#indicator.time = 0
       this.#indicator.start()
@@ -403,16 +408,15 @@ class ChatStatusBarBehavior extends Behavior {
 
   showFaceBar(container: Container) {
     if (this.#mode.kind !== 'face') return
-    this.setFaceBarVisible(container, true)
+    this.setFaceBarVisible(true)
     container.stop()
     container.duration = FACE_ACTIONS_VISIBLE_MS
     container.time = 0
     container.start()
   }
 
-  setFaceBarVisible(container: Container, visible: boolean) {
+  setFaceBarVisible(visible: boolean) {
     this.#faceBarVisible = visible && this.#mode.kind === 'face'
-    container.visible = this.#faceBarVisible
     this.updateFaceActions()
     this.updateUI()
   }

--- a/firmware/host/modules/ui/views/main/__tests__/face-view-state/face-view-state.test.ts
+++ b/firmware/host/modules/ui/views/main/__tests__/face-view-state/face-view-state.test.ts
@@ -32,7 +32,9 @@ type RecorderBehavior = {
 }
 
 type BalloonNode = Content & {
+  next?: BalloonNode | null
   skin?: unknown
+  string?: string
 }
 
 type BalloonContent = PiuContainer & {
@@ -40,6 +42,7 @@ type BalloonContent = PiuContainer & {
   behavior?: {
     onDisplaying?: (content: PiuContainer) => void
     onFaceState?: (content: PiuContainer, face: FaceState) => void
+    setText?: (content: PiuContainer, text: string) => void
   }
 }
 
@@ -459,6 +462,20 @@ assert(
   attachedBalloon.first?.skin !== defaultSkin,
   'showBalloon should replay the active face state to newly attached balloons',
 )
+const initialBalloonHeight = positionedBalloon.coordinates?.height
+runtimeUI.showBalloon('runtime balloon\nsecond line\nthird line')
+equal(appData.EFFECTS?.last, runtimeBalloon, 'showBalloon should reuse a balloon when layout options are unchanged')
+equal(
+  attachedBalloon.first?.next?.string,
+  'runtime balloon\nsecond line\nthird line',
+  'showBalloon should update reused balloon text in place',
+)
+assert(
+  (positionedBalloon.coordinates?.height ?? 0) > (initialBalloonHeight ?? 0),
+  'showBalloon should recalculate a reused balloon height',
+)
+runtimeUI.showBalloon('top balloon', { top: 8 })
+assert(appData.EFFECTS?.last !== runtimeBalloon, 'showBalloon should replace a balloon when layout options change')
 runtimeUI.hideBalloon()
 
 const oldDrawerCalls: DrawerControllerCalls = { buttons: [], states: [], removed: [] }


### PR DESCRIPTION
## Summary

- expose reliable top-touch tap metadata and allow multiple subscribers
- keep the microphone indicator clear of the battery/AppBar presentation
- require a longer intentional swipe while preserving double-tap recognition
- cover touch, status-bar, and face-view behavior with regression tests

## Compatibility

The implementation branch starts at 3f2aeef7, the hardware-verified XiaoZhi audio baseline. The XiaoZhi transport contract is unchanged.

## Verification

- npm run format
- npm run lint (one pre-existing informational finding in the crypt test fake)
- npm run test:unit: 403 passed
- focused Moddable chat-status-bar test passed
- CoreS3 release build and flash verification passed
- verified on /dev/ttyACM1: AppBar/microphone placement, top-touch taps, long swipes, and XiaoZhi conversation start/stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tap recognition with position, duration, and movement details for touch interactions.
  * Added support for multiple touch-event listeners while preserving existing interactions.
  * Improved speech balloons by updating streaming text in place when layout remains unchanged.

* **Improvements**
  * Microphone/input status now remains visible during user interaction.
  * Refined touch gesture thresholds for more reliable tap and swipe detection.
  * Improved speech-balloon sizing and replacement when display options change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->