### PR TITLE
fix(firmware): increase CoreS3 XS stack

### DIFF
--- a/.changeset/steady-cores3-stack.md
+++ b/.changeset/steady-cores3-stack.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Increase the M5StackChan CoreS3 XS stack to prevent a boot-time stack overflow.

--- a/firmware/host/platforms/esp32/manifest.json
+++ b/firmware/host/platforms/esp32/manifest.json
@@ -122,7 +122,7 @@
           "initial": 4608,
           "incremental": 1280
         },
-        "stack": 512,
+        "stack": 768,
         "keys": {
           "initial": 32,
           "incremental": 32


### PR DESCRIPTION
## Summary

- Increase the M5StackChan CoreS3 XS stack from 512 to 768.
- Prevent the web-flashed release firmware from rebooting on a boot-time XS stack overflow.

## Release impact

patch

## Verification

- `npm run format` (677 files)
- `npm run check:manifest` (6 targets)
- `npm run test:unit` (403 tests)
- `npm run build:release:m5stackchan_cores3`
- Flashed the release host application to a physical M5StackChan CoreS3.
- Verified two consecutive boots reached app context creation without `stack overflow (-1)!` or an unintended reboot.
- Verified Wi-Fi, the stack-chan-ai MOD startup, and the AI control WebSocket connection.
- Verified the flashed app and existing MOD partition digests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup stability on the M5StackChan CoreS3 XS by increasing available creation stack space.
  - Prevented boot-time stack overflow issues.

- **Chores**
  - Documented the patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->