### PR TITLE
fix(firmware): align CoreS3 XS creation stacks

### DIFF
--- a/.changeset/steady-cores3-stack.md
+++ b/.changeset/steady-cores3-stack.md
@@ -2,4 +2,4 @@
 "stack-chan": patch
 ---
 
-Increase the M5StackChan CoreS3 XS stack to prevent a boot-time stack overflow.
+Increase the CoreS3 XS stack to prevent a boot-time stack overflow.

--- a/firmware/host/platforms/esp32/manifest.json
+++ b/firmware/host/platforms/esp32/manifest.json
@@ -82,7 +82,7 @@
           "initial": 4608,
           "incremental": 1280
         },
-        "stack": 512,
+        "stack": 768,
         "keys": {
           "initial": 32,
           "incremental": 32
@@ -140,7 +140,7 @@
           "initial": 4608,
           "incremental": 1280
         },
-        "stack": 512,
+        "stack": 768,
         "keys": {
           "initial": 32,
           "incremental": 32


### PR DESCRIPTION
## Summary

- align the CoreS3 base target and both subplatform XS creation blocks at `stack: 768`
- keep the hardware-verified M5StackChan CoreS3 setting from #673
- update the existing patch changeset to describe all CoreS3 targets

#673 exposed an existing architecture invariant: `m5stack_cores3`, `m5stackchan_cores3`, and `stackchan_rt` must share the same XS creation block. This follow-up preserves that invariant without weakening the architecture test.

## Release impact

- patch

## Verification

- `npm run check:architecture`: 78 passed
- `npm run check:manifest`: 6 targets passed
- `npm run test:unit`: 403 passed
- `npm run format`: 677 files checked, no fixes
- `git diff --check`: passed
- M5StackChan CoreS3 at `stack: 768` was hardware-verified in #673 with two clean boots and no stack overflow or unintended reset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability for CoreS3 XS-based devices by increasing available creation stack capacity.
  - Applied the same stability improvement to StackChan RT configurations.

- **Documentation**
  - Updated release information to accurately refer to the CoreS3 XS stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->