### PR TITLE
feat(firmware): expose touch sensor samples

### DIFF
--- a/.changeset/observable-touch-samples.md
+++ b/.changeset/observable-touch-samples.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": minor
+---
+
+Expose the latest head-touch sensor channel values to installed MODs and avoid redundant input-level layout updates.

--- a/firmware/host/modules/input/__tests__/touch-panel/touch-panel.test.ts
+++ b/firmware/host/modules/input/__tests__/touch-panel/touch-panel.test.ts
@@ -52,6 +52,7 @@ async function runTest(): Promise<void> {
   const touchPanel = new TouchPanel(FakeTouchPanelDriver, { interval: 10 })
   const driver = FakeTouchPanelDriver.current
   assert(driver, 'TouchPanel should instantiate its driver')
+  equal(touchPanel.sample.length, 0, 'sample should be empty before the first poll')
 
   const legacyEvents: TouchPanelInputEvent[] = []
   const subscriberEvents: TouchPanelInputEvent[] = []
@@ -66,6 +67,7 @@ async function runTest(): Promise<void> {
   driver.queue([0, 1, 0], [0, 0, 0])
   touchPanel.start()
   await waitForSampleCount(driver, 2)
+  equal(touchPanel.sample.join(','), '0,0,0', 'sample should expose the latest raw channel values')
 
   assertPressAndRelease(legacyEvents, 'legacy onEvent')
   assertPressAndRelease(subscriberEvents, 'subscriber')

--- a/firmware/host/modules/input/touch-panel.ts
+++ b/firmware/host/modules/input/touch-panel.ts
@@ -63,6 +63,10 @@ export default class TouchPanel {
     this.#driver.configure?.(options)
   }
 
+  get sample(): readonly number[] {
+    return this.#lastSample
+  }
+
   subscribe(listener: (event: TouchPanelInputEvent) => void): () => void {
     this.#listeners.add(listener)
     return () => this.#listeners.delete(listener)

--- a/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
+++ b/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
@@ -408,6 +408,7 @@ class ChatStatusBarBehavior extends Behavior {
     if (!this.#levelTrack || !this.#levelFill) return
     const ratio = Math.min(Math.max(this.#inputLevel / 2000, 0), 1)
     const height = Math.round(levelHeight * ratio)
+    if (this.#levelFill.height === height) return
     this.#levelFill.height = height
   }
 


### PR DESCRIPTION
## Summary

- expose the latest raw head-touch channel sample through `TouchPanel.sample`
- skip redundant input-level height assignments in the chat status bar
- keep equal non-zero Si12T samples observable instead of suppressing them with a heuristic

## Release impact

- **minor**: installed MODs gain read access to the latest touch-panel sample
- changeset: `.changeset/observable-touch-samples.md`

## Verification

- TouchPanel Moddable integration test passed
- ChatStatusBar Moddable test passed
- full firmware Node test suite passed: 403/403
- Biome checks and `git diff --check` passed
- M5StackChan CoreS3 release host built and flashed successfully; bootloader, partition table, and 6,428,336-byte app image passed flash hash verification
- actual device retained smooth face rendering and supported AI conversation plus the touch-sensor monitor MOD

## Hardware note

One sensor channel was observed once with a lower bound stuck at 2, preventing touch recognition. A reboot cleared it and it has not reproduced. This PR deliberately leaves the raw sample unchanged so the condition can be observed if it recurs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installed MODs can now access the latest raw values from the head-touch sensor channels.

* **Performance Improvements**
  * Input-level display updates are skipped when the value has not changed, reducing unnecessary UI work.

* **Documentation**
  * Added release notes for the upcoming minor `stack-chan` update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->