### PR TITLE
fix: address post-release review findings

### DIFF
--- a/.changeset/steady-project-builds.md
+++ b/.changeset/steady-project-builds.md
@@ -1,0 +1,5 @@
+---
+"stackchan-web": patch
+---
+
+Invalidate stale MOD build results when a project is renamed.

--- a/.github/scripts/update-pages-bundle.mjs
+++ b/.github/scripts/update-pages-bundle.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import { cp, lstat, mkdir, readdir, rm } from 'node:fs/promises'
+import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+async function requireNonEmptyDirectory(directory, label) {
+  const root = resolve(directory)
+  const stat = await lstat(root)
+  if (!stat.isDirectory()) throw new Error(`${label} is not a directory: ${root}`)
+  if ((await readdir(root)).length === 0) throw new Error(`${label} is empty: ${root}`)
+  return root
+}
+
+async function requireNonEmptyFile(file, label) {
+  const path = resolve(file)
+  const stat = await lstat(path)
+  if (!stat.isFile() || stat.size === 0) throw new Error(`${label} is empty or invalid: ${path}`)
+  return path
+}
+
+function resolvePagesDestination(pagesRoot, pagesDirectory) {
+  if (!pagesDirectory || isAbsolute(pagesDirectory)) {
+    throw new Error('Pages directory must be a non-empty relative path')
+  }
+  const root = resolve(pagesRoot)
+  const target = resolve(root, pagesDirectory)
+  const relativeTarget = relative(root, target)
+  if (!relativeTarget || relativeTarget === '..' || relativeTarget.startsWith(`..${sep}`)) {
+    throw new Error(`Pages directory escapes the Pages root: ${pagesDirectory}`)
+  }
+  return { root, target }
+}
+
+async function copyDirectoryContents(source, destination, skippedNames = new Set()) {
+  await mkdir(destination, { recursive: true })
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    if (skippedNames.has(entry.name)) continue
+    await cp(join(source, entry.name), join(destination, entry.name), {
+      recursive: true,
+      force: true,
+    })
+  }
+}
+
+export async function updatePagesBundle({
+  webDirectory,
+  firmwareDirectory,
+  schemaFile,
+  pagesRoot,
+  pagesDirectory,
+  schematicsDirectory,
+}) {
+  const webRoot = await requireNonEmptyDirectory(webDirectory, 'Web application artifact')
+  const firmwareRoot = await requireNonEmptyDirectory(firmwareDirectory, 'Firmware bundle artifact')
+  const schemaPath = await requireNonEmptyFile(schemaFile, 'MOD schema')
+  await requireNonEmptyFile(join(webRoot, 'simulator/mc.js'), 'Simulator JavaScript')
+  await requireNonEmptyFile(join(webRoot, 'simulator/mc.wasm'), 'Simulator WebAssembly')
+
+  const candidateSchematics = schematicsDirectory
+    ? await requireNonEmptyDirectory(schematicsDirectory, 'Schematics artifact')
+    : undefined
+  if (candidateSchematics) {
+    await requireNonEmptyFile(join(candidateSchematics, 'index.html'), 'Schematics index')
+  }
+
+  const { target } = resolvePagesDestination(pagesRoot, pagesDirectory)
+  await mkdir(target, { recursive: true })
+  for (const entry of await readdir(target, { withFileTypes: true })) {
+    if (!candidateSchematics && entry.name === 'schematics') continue
+    await rm(join(target, entry.name), { recursive: true, force: true })
+  }
+
+  await copyDirectoryContents(webRoot, target, new Set(['schematics']))
+
+  const firmwareTarget = join(target, 'flash/tech.moddable.stackchan')
+  await rm(firmwareTarget, { recursive: true, force: true })
+  await copyDirectoryContents(firmwareRoot, firmwareTarget)
+
+  const schemaTarget = join(target, 'schemas/stackchan-mod.schema.json')
+  await mkdir(join(target, 'schemas'), { recursive: true })
+  await cp(schemaPath, schemaTarget, { force: true })
+
+  if (candidateSchematics) {
+    const schematicsTarget = join(target, 'schematics')
+    await rm(schematicsTarget, { recursive: true, force: true })
+    await copyDirectoryContents(candidateSchematics, schematicsTarget)
+  }
+
+  return { targetDirectory: target }
+}
+
+const isMain = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+if (isMain) {
+  const [webDirectory, firmwareDirectory, schemaFile, pagesRoot, pagesDirectory, schematicsDirectory] =
+    process.argv.slice(2)
+  if (!webDirectory || !firmwareDirectory || !schemaFile || !pagesRoot || !pagesDirectory) {
+    console.error(
+      'Usage: update-pages-bundle.mjs <web-directory> <firmware-directory> <schema-file> <pages-root> <pages-directory> [schematics-directory]'
+    )
+    process.exit(2)
+  }
+  try {
+    const result = await updatePagesBundle({
+      webDirectory,
+      firmwareDirectory,
+      schemaFile,
+      pagesRoot,
+      pagesDirectory,
+      schematicsDirectory,
+    })
+    console.log(`Updated Pages bundle at ${result.targetDirectory}`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}

--- a/.github/scripts/update-pages-bundle.test.mjs
+++ b/.github/scripts/update-pages-bundle.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { updatePagesBundle } from './update-pages-bundle.mjs'
+
+async function write(path, contents) {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, contents)
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'stackchan-pages-bundle-'))
+  const webDirectory = join(root, 'web-dist')
+  const firmwareDirectory = join(root, 'firmware-bundle')
+  const schemaFile = join(root, 'source/stackchan-mod.schema.json')
+  const schematicsDirectory = join(root, 'candidate-schematics')
+  const pagesRoot = join(root, 'pages')
+
+  await write(join(webDirectory, 'index.html'), 'candidate web')
+  await write(join(webDirectory, 'simulator/mc.js'), 'candidate simulator JavaScript')
+  await write(join(webDirectory, 'simulator/mc.wasm'), 'candidate simulator WebAssembly')
+  await write(join(webDirectory, 'flash/tech.moddable.stackchan/stale.bin'), 'stale web firmware')
+  await write(join(webDirectory, 'schematics/index.html'), 'stale web schematics')
+  await write(join(firmwareDirectory, 'm5stackchan_cores3/xs_esp32.bin'), 'candidate firmware')
+  await write(schemaFile, '{"candidate":true}')
+  await write(join(schematicsDirectory, 'index.html'), 'candidate schematics')
+
+  return {
+    root,
+    webDirectory,
+    firmwareDirectory,
+    schemaFile,
+    schematicsDirectory,
+    pagesRoot,
+  }
+}
+
+test('updates the selected Pages channel with candidate artifacts', async (t) => {
+  const paths = await fixture()
+  t.after(() => rm(paths.root, { recursive: true, force: true }))
+  const destination = join(paths.pagesRoot, 'develop/web')
+  await write(join(destination, 'obsolete.txt'), 'obsolete')
+  await write(join(destination, 'schematics/index.html'), 'baseline schematics')
+
+  const result = await updatePagesBundle({
+    ...paths,
+    pagesDirectory: 'develop/web',
+  })
+
+  assert.equal(result.targetDirectory, destination)
+  assert.equal(await readFile(join(destination, 'index.html'), 'utf8'), 'candidate web')
+  assert.equal(
+    await readFile(join(destination, 'flash/tech.moddable.stackchan/m5stackchan_cores3/xs_esp32.bin'), 'utf8'),
+    'candidate firmware'
+  )
+  assert.equal(await readFile(join(destination, 'schemas/stackchan-mod.schema.json'), 'utf8'), '{"candidate":true}')
+  assert.equal(await readFile(join(destination, 'schematics/index.html'), 'utf8'), 'candidate schematics')
+  await assert.rejects(access(join(destination, 'obsolete.txt')), {
+    code: 'ENOENT',
+  })
+  await assert.rejects(access(join(destination, 'flash/tech.moddable.stackchan/stale.bin')), { code: 'ENOENT' })
+})
+
+test('preserves separately deployed schematics when no candidate artifact is supplied', async (t) => {
+  const paths = await fixture()
+  t.after(() => rm(paths.root, { recursive: true, force: true }))
+  const destination = join(paths.pagesRoot, 'web')
+  await write(join(destination, 'schematics/index.html'), 'published schematics')
+
+  await updatePagesBundle({
+    webDirectory: paths.webDirectory,
+    firmwareDirectory: paths.firmwareDirectory,
+    schemaFile: paths.schemaFile,
+    pagesRoot: paths.pagesRoot,
+    pagesDirectory: 'web',
+  })
+
+  assert.equal(await readFile(join(destination, 'schematics/index.html'), 'utf8'), 'published schematics')
+  assert.equal(await readFile(join(destination, 'schemas/stackchan-mod.schema.json'), 'utf8'), '{"candidate":true}')
+})
+
+test('rejects a Pages destination outside the selected root', async (t) => {
+  const paths = await fixture()
+  t.after(() => rm(paths.root, { recursive: true, force: true }))
+
+  await assert.rejects(
+    updatePagesBundle({
+      webDirectory: paths.webDirectory,
+      firmwareDirectory: paths.firmwareDirectory,
+      schemaFile: paths.schemaFile,
+      pagesRoot: paths.pagesRoot,
+      pagesDirectory: '../outside',
+    }),
+    /escapes the Pages root/
+  )
+})

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "firmware/**"
       - "web/**"
+      - "**/*.kicad_sch"
+      - "**/*.kicad_pcb"
+      - "schematics/**/*.kibot.yaml"
       - ".github/scripts/**"
       - ".github/actions/setup/action.yml"
       - ".github/workflows/bundle.yml"
@@ -19,6 +22,9 @@ on:
     paths:
       - "firmware/**"
       - "web/**"
+      - "**/*.kicad_sch"
+      - "**/*.kicad_pcb"
+      - "schematics/**/*.kibot.yaml"
       - ".github/scripts/**"
       - ".github/actions/setup/action.yml"
       - ".github/workflows/bundle.yml"
@@ -124,6 +130,14 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+      - name: Build candidate schematics
+        if: github.event_name == 'pull_request'
+        uses: INTI-CMNB/KiBot@v2_k7
+        with:
+          config: schematics/m5-pantilt/m5-pantilt.kibot.yaml
+          schema: schematics/m5-pantilt/m5-pantilt.kicad_sch
+          board: schematics/m5-pantilt/m5-pantilt.kicad_pcb
+          dir: pages-schematics
       - name: Download bundle targets
         uses: actions/download-artifact@v8
         with:
@@ -144,32 +158,16 @@ jobs:
         with:
           name: web-dist
           path: ./web/dist
-      - name: Checkout Pages baseline
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v7
-        with:
-          ref: gh-pages
-          path: pages-baseline
-          persist-credentials: false
       - name: Assemble Cloudflare Pages preview
         if: github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-          test -s ./pages-baseline/web/schematics/index.html
-          mkdir -p ./pages-preview
-          cp -R ./web/dist/. ./pages-preview/
-          rm -rf \
-            ./pages-preview/schematics \
-            ./pages-preview/flash/tech.moddable.stackchan
-          mkdir -p ./pages-preview/flash/tech.moddable.stackchan
-          cp -R ./pages-baseline/web/schematics ./pages-preview/schematics
-          cp -R \
-            ./firmware/host/app/tech.moddable.stackchan/. \
-            ./pages-preview/flash/tech.moddable.stackchan/
-          mkdir -p ./pages-preview/schemas
-          cp \
-            ./docs/specs/stackchan-mod.schema.json \
-            ./pages-preview/schemas/stackchan-mod.schema.json
+        run: >-
+          node .github/scripts/update-pages-bundle.mjs
+          ./web/dist
+          ./firmware/host/app/tech.moddable.stackchan
+          ./docs/specs/stackchan-mod.schema.json
+          .
+          pages-preview
+          ./pages-schematics
       - name: Validate Cloudflare Pages preview
         if: github.event_name == 'pull_request'
         run: |
@@ -220,29 +218,13 @@ jobs:
           name: web-dist
           path: ./web-dist
       - name: Update bundle files
-        run: |
-          set -euo pipefail
-          if [ -z "$(find ./firmware-bundle -mindepth 1 -print -quit)" ]; then
-            echo "Firmware bundle artifact is empty"
-            exit 1
-          fi
-          if [ -z "$(find ./web-dist -mindepth 1 -print -quit)" ]; then
-            echo "Web application artifact is empty"
-            exit 1
-          fi
-          test -s ./web-dist/simulator/mc.js
-          test -s ./web-dist/simulator/mc.wasm
-          target_directory="./$PAGES_DIRECTORY"
-          mkdir -p "$target_directory"
-          rsync -a --delete \
-            --exclude '/schematics/' \
-            --exclude '/flash/tech.moddable.stackchan/' \
-            ./web-dist/ "$target_directory/"
-          rm -rf "$target_directory/flash/tech.moddable.stackchan"
-          mkdir -p "$target_directory/flash/tech.moddable.stackchan"
-          cp -R ./firmware-bundle/. "$target_directory/flash/tech.moddable.stackchan/"
-          mkdir -p "$target_directory/schemas"
-          cp ./website-source/docs/specs/stackchan-mod.schema.json "$target_directory/schemas/stackchan-mod.schema.json"
+        run: >-
+          node ./website-source/.github/scripts/update-pages-bundle.mjs
+          ./web-dist
+          ./firmware-bundle
+          ./website-source/docs/specs/stackchan-mod.schema.json
+          .
+          "$PAGES_DIRECTORY"
       - name: Commit bundle update
         run: |
           set -euo pipefail

--- a/docs/operations/release-device-test_ja.md
+++ b/docs/operations/release-device-test_ja.md
@@ -126,6 +126,8 @@
   Bearer tokenがURLへ露出せず、接続、マイク入力、文字起こし、音声応答、tool callと結果返却が一往復することを確認する。
 - [ ] `C-09` Codex Voiceなどで英大文字を含む認証コードとactivation linkを表示する。
   文字が欠けず、QRコードが標準ホストとWASMホストの両方で描画され、読み取ったURLが表示内容と一致することを確認する。
+- [ ] `C-10` XiaoZhi v1互換サーバーへ`ChatService`で接続する。
+  CoreS3のOpusマイク入力と音声応答を確認し、text eventとMCPの初期化、tool call、結果返却を一往復させた後、切断から再接続できることを確認する。
 
 ## 追加機種の確認
 

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -47,3 +47,4 @@ GitHub Pages keeps stable and development artifacts in separate directories on t
 A push to `main` updates only the canonical site, and a push to `develop` updates only the development site.
 Each directory contains the Web application, firmware bundle, schema, and schematics built from its source branch.
 A `release/*` branch does not deploy directly to GitHub Pages and is checked through its per-pull-request Cloudflare preview.
+The preview uses the Web application, firmware bundle, and schematics generated from the pull-request candidate together with that candidate's schema; it does not reuse generated artifacts from the `gh-pages` baseline.

--- a/docs/operations/release-flow_ja.md
+++ b/docs/operations/release-flow_ja.md
@@ -55,3 +55,4 @@ GitHub Pagesは`gh-pages`ブランチ内で安定版と開発版を別のディ�
 `main`へのpushは正本だけを更新し、`develop`へのpushは開発版だけを更新します。
 各ディレクトリには、その元ブランチからビルドしたWebアプリ、firmware bundle、schema、schematicsを配置します。
 `release/*`はGitHub Pagesへ直接デプロイせず、pull requestごとのCloudflareプレビューで確認します。
+プレビューにはpull requestの候補から生成したWebアプリ、firmware bundle、schematicsと、その候補に含まれるschemaを使用し、`gh-pages`上の生成済み成果物は流用しません。

--- a/docs/release-notes/v1.1.0.md
+++ b/docs/release-notes/v1.1.0.md
@@ -61,6 +61,8 @@ SHA-256は同時に公開する`.sha256`ファイルで確認できます。
 
 実機検証は[リリース前実機テスト](../operations/release-device-test_ja.md)に従って実施し、対象コミットと結果をリリースPRへ記録します。
 v1.1.0では共通項目に加え、`C-01`から`C-05`、`C-08`、`C-09`を対象とします。
+`C-08`は既存のOpenAI Realtime経路を対象とします。
+XiaoZhi `ChatService`のOpus音声、テキストイベント、MCPイベントは自動化したModdableテストで検証しており、`C-10`の実機相互運用はv1.1.0の実機ゲートに含めていません。
 
 ## 既知の制限
 
@@ -135,6 +137,8 @@ Verify the download with the accompanying `.sha256` file.
 
 Record the tested commit and results in the release pull request using the [physical-device release checklist](../operations/release-device-test_ja.md).
 For v1.1.0, run change-specific cases `C-01` through `C-05`, `C-08`, and `C-09` in addition to the common gate.
+`C-08` covers the retained OpenAI Realtime path.
+Automated Moddable tests cover XiaoZhi `ChatService` Opus audio and text/MCP events; the v1.1.0 physical-device gate does not claim the `C-10` interoperability check.
 
 ## Known limitations
 

--- a/web/mod-gallery/mod-definition.test.mjs
+++ b/web/mod-gallery/mod-definition.test.mjs
@@ -272,9 +272,4 @@ test('JSON Schemaと実装が同じ形式識別子と必須フィールドを持
   }
   assert.equal(new RegExp(schema.properties.setup.properties.url.pattern).test('https://example.test/setup'), true)
   assert.equal(new RegExp(schema.properties.setup.properties.url.pattern).test('http://example.test/setup'), false)
-  const workflow = readFileSync(new URL('../../.github/workflows/bundle.yml', import.meta.url), 'utf8')
-  assert.match(
-    workflow,
-    /website-source\/docs\/specs\/stackchan-mod\.schema\.json "\$target_directory\/schemas\/stackchan-mod\.schema\.json"/
-  )
 })

--- a/web/src/features/project-editor/use-project-editor.test.tsx
+++ b/web/src/features/project-editor/use-project-editor.test.tsx
@@ -52,6 +52,10 @@ const invalidationScenarios: Array<{
     invalidate: (editor) => editor.setTarget('simulator'),
   },
   {
+    name: 'the project name changes',
+    invalidate: (editor) => editor.setName('Renamed project'),
+  },
+  {
     name: 'the embedded assets change',
     invalidate: (editor) =>
       editor.addAssets([

--- a/web/src/features/project-editor/use-project-editor.ts
+++ b/web/src/features/project-editor/use-project-editor.ts
@@ -326,7 +326,7 @@ export function useProjectEditor() {
       }) as VisualProject
       persistProject(next)
       const shouldInvalidateBuild = changedEntries.some(
-        ([key]) => key === 'target' || key === 'assets' || key === 'settings'
+        ([key]) => key === 'name' || key === 'target' || key === 'assets' || key === 'settings'
       )
       if (shouldInvalidateBuild) {
         const currentSnapshot = workspaceRef.current?.snapshot() ?? snapshot


### PR DESCRIPTION
## Summary

- generate pull-request preview schematics from the candidate with KiBot instead of reusing the `gh-pages` baseline
- move Pages bundle updates into a fixture-tested helper and remove the workflow source-text assertion
- invalidate in-flight MOD builds when the project name changes
- distinguish the retained OpenAI Realtime `C-08` gate from automated XiaoZhi coverage and add dedicated device case `C-10`

## Release impact

- **patch** — project rename now invalidates stale Web editor build results
- Changeset: `.changeset/steady-project-builds.md`
- workflow and documentation changes do not change the firmware runtime

## Validation

- `.github/scripts` tests: 25 passed
- Web legacy tests: 206 passed
- Web React tests: 51 passed
- Web production build passed
- targeted Pages fixture, MOD schema, and project-editor tests passed
- `bundle.yml` parsed as YAML; Prettier and `git diff --check` passed

## Integration

- follows the v1.1.0 main-to-develop backmerge in #681
- keeps `main` and the published `v1.1.0` tag unchanged
- addresses the accepted CodeRabbit findings recorded on #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull-request previews now use freshly generated web, firmware, schema, and schematics artifacts.
  * Added support for previewing candidate schematics and safely refreshing bundled assets.

* **Bug Fixes**
  * Renaming a project now discards stale build results.
  * Preview bundles remove outdated files while preserving separately deployed schematics when appropriate.

* **Documentation**
  * Updated release and operations guidance for artifact-based previews and device testing.
  * Clarified validation coverage for XiaoZhi and OpenAI Realtime integrations.

* **Tests**
  * Added coverage for artifact bundling, stale-file cleanup, path safety, and renamed-project builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->