### PR TITLE
feat(firmware): CoreS3にJitomeFaceを追加

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ inputs:
   target-branch:
     description: "Target branch or tag to setup environment"
     required: false
-    default: ""
+    default: "9.5.0"
   install-emscripten:
     description: "Install Emscripten for WASM builds"
     required: false

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          target-branch: "9.0.0"
+          target-branch: "9.5.0"
       - name: Build release firmware
         working-directory: ./firmware
         run: source "$HOME/.local/share/xs-dev-export.sh" && ${{ matrix.command }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup firmware toolchain
         uses: ./.github/actions/setup
         with:
-          target-branch: "9.0.0"
+          target-branch: "9.5.0"
       - name: Build firmware bundle
         working-directory: ./firmware
         run: source "$HOME/.local/share/xs-dev-export.sh" && npm run bundle

--- a/docs/release-notes/jitome-face.md
+++ b/docs/release-notes/jitome-face.md
@@ -1,0 +1,8 @@
+# JitomeFace
+
+Release impact: minor
+
+M5Stack CoreS3向けに、ジト目と小さな口の単色Faceを本体のFace選択へ追加しました。
+瞬きは虹彩を固定し、まぶた・まつ毛と眉を下げます。視線・口パク・テーマに対応します。
+Moddable 9.5.0の`Outline.clone(destination)`を利用し、SDKへの独自パッチなしで輪郭を再利用します。9.5.0未満では選択肢を表示しません。
+標準Faceの選択は変更しません。

--- a/firmware/benchmarks/jitome-face/README.md
+++ b/firmware/benchmarks/jitome-face/README.md
@@ -1,0 +1,23 @@
+# JitomeFace CoreS3 benchmark
+
+The instrumented benchmark runs four 18-second phases on a 320x240 M5Stack
+CoreS3: static, unchanged FaceState delivery at 30 fps, blink-only animation at
+30 fps, and worst-case eye/gaze/mouth motion at 30 fps. Discard the first five
+one-second instrumentation samples in each phase. `Frames Drawn` counts Piu/Poco
+frame submissions rather than LCD scanout refreshes. CPU values are whole-core
+non-idle load, not time attributed only to JitomeFace.
+
+Build and flash from `firmware/` with the clean Moddable 9.5.0 and ESP-IDF 6.1
+environments active:
+
+```sh
+npm run benchmark:jitome-face:build:cores3
+UPLOAD_PORT=/dev/ttyACM0 npm run benchmark:jitome-face:flash:cores3
+UPLOAD_PORT=/dev/ttyACM0 npm run benchmark:jitome-face:capture:cores3
+```
+
+The capture command resets the installed benchmark, saves the raw serial output
+to `dist/jitome-face-benchmark/run.log`, and writes the computed phase statistics
+to `dist/jitome-face-benchmark/result.json`. It uses the active ESP-IDF Python
+environment for serial reset; set `ESP_IDF_PYTHON` when that interpreter is not
+named `python3` on `PATH`.

--- a/firmware/benchmarks/jitome-face/main.js
+++ b/firmware/benchmarks/jitome-face/main.js
@@ -1,0 +1,75 @@
+import { createFaceState } from 'face-state'
+import { createJitomeFace } from 'jitome-face'
+import { Application, Skin } from 'piu/MC'
+import Time from 'time'
+
+const PHASE_DURATION = 18000
+const phases = ['static', 'unchanged-30fps', 'blink-30fps', 'full-motion-30fps']
+const state = createFaceState()
+const face = createJitomeFace()
+const behavior = face.content.behavior
+behavior.enabled = false
+
+let phase = 0
+let phaseStarted = 0
+let ticks = 0
+let updates = 0
+let step = 0
+
+function beginPhase() {
+  phaseStarted = Time.ticks
+  ticks = 0
+  updates = 0
+  step = 0
+  state.eyes.left.open = state.eyes.right.open = 1
+  state.eyes.left.gazeX = state.eyes.left.gazeY = 0
+  state.eyes.right.gazeX = state.eyes.right.gazeY = 0
+  state.mouth.open = 0
+  behavior.onFaceUpdate(face.content, state)
+  trace(`[JITOME-BENCH] phase=${phases[phase]}\n`)
+}
+
+function updateFace() {
+  if (phase === 0) return
+  if (phase === 2) {
+    const t = step % 60
+    state.eyes.left.open = state.eyes.right.open = t < 30 ? 1 - t / 29 : (t - 30) / 29
+  } else if (phase === 3) {
+    const t = step % 60
+    state.eyes.left.open = t < 30 ? 1 - t / 29 : (t - 30) / 29
+    state.eyes.right.open = 1 - state.eyes.left.open
+    state.eyes.left.gazeX = ((step % 41) - 20) / 20
+    state.eyes.left.gazeY = ((step % 37) - 18) / 18
+    state.eyes.right.gazeX = ((step % 43) - 21) / 21
+    state.eyes.right.gazeY = ((step % 47) - 23) / 23
+    state.mouth.open = (step % 31) / 30
+  }
+  behavior.onFaceUpdate(face.content, state)
+  updates++
+  step++
+}
+
+export default new Application(null, {
+  pixels: 320 * 48,
+  skin: new Skin({ fill: 'black' }),
+  contents: [face.content],
+  Behavior: class extends Behavior {
+    onDisplaying(application) {
+      application.interval = 33
+      beginPhase()
+      application.start()
+    }
+    onTimeChanged(application) {
+      ticks++
+      updateFace()
+      const elapsed = Time.ticks - phaseStarted
+      if (elapsed < PHASE_DURATION) return
+      trace(`[JITOME-BENCH] result phase=${phases[phase]} elapsed=${elapsed} ticks=${ticks} updates=${updates}\n`)
+      phase++
+      if (phase === phases.length) {
+        application.stop()
+        trace('[JITOME-BENCH] complete\n')
+      } else beginPhase()
+    }
+  },
+})

--- a/firmware/benchmarks/jitome-face/manifest.json
+++ b/firmware/benchmarks/jitome-face/manifest.json
@@ -1,0 +1,30 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "$(MODDABLE)/examples/manifest_piu.json",
+    "$(MODDABLE)/modules/base/instrumentation/manifest.json",
+    "../../host/modules/ui/components/face/jitome/manifest.json"
+  ],
+  "modules": {
+    "main": "./main",
+    "face-state": "../../host/modules/ui/state/face-state",
+    "face-skin": "../../host/modules/ui/state/face-skin"
+  },
+  "config": { "startupSound": false },
+  "creation": { "stack": 1024 },
+  "platforms": {
+    "esp32/m5stack_cores3": {
+      "defines": {
+        "xs": { "task_core": 1 },
+        "spi": {
+          "esp32_task_core": 0,
+          "esp32_isr_core": 0,
+          "esp32_transactionsize": 4096,
+          "esp32_blocking_wait": 1,
+          "esp32_polling_limit": 0
+        }
+      }
+    }
+  }
+}

--- a/firmware/docs/0004-jitome-face.md
+++ b/firmware/docs/0004-jitome-face.md
@@ -1,0 +1,72 @@
+# JitomeFace (M5Stack CoreS3)
+
+承認済み320×240プレビューの単色Face。髪・帽子・顔外周・鼻・下まぶたは描画しません。
+本体の組み込みFaceとしてDrawerから「ジト目」を選択できます。標準起動FaceはSimpleのままです。
+
+画面全体を使うため、Behaviorの`preservePositionOnSwap = false`で前のFaceの座標を引き継がず、画面原点(0,0)へ配置します。他のFaceは従来どおり交換前の位置を引き継ぎます。
+
+```json
+{
+  "ui": { "type": "jitome" }
+}
+```
+
+## 見た目と動き
+
+内部の基準座標（左右眼中心x=102.5／217.5、上まぶたy=127、眉y=112.5、口中心(160,174)）を、顔中心(160,144)の周りで一律1.5倍に拡大して320×240画面へ描画します。さらに左右の目一式を拡大後に各4px中央へ寄せるため、最終的な左右眼中心はx=77.75／242.25、上まぶた幅61.5px、虹彩幅約48px、口中心y=189、口幅18pxになります。
+
+FaceStateの開眼量1で通常のジト目、0で閉眼します。瞬きでは虹彩の点列を変更せず、背景色のまぶたとまつ毛を下降させて覆います。眉は基準で最大2px（拡大後3px）下降します。視線入力だけが虹彩を変えます。口パクは幅を維持して開口量を変え、静止時は小さな楕円です。テーマは既存FaceStateに従います。感情別の別造形、呼吸・回転・伸縮は追加していません。
+
+33ms間隔の自動瞬きを備え、90msで閉じ、45ms閉眼を保ち、200msで開きます。周期は約2.8～5秒。瞬き中に自動視線は加えません。外部視線・左右別開眼・口パクに対応します。`robot.ui.setFaceMotionEnabled(false)`で自動瞬きを停止して入力を直接描画します。非表示・Face交換時はタイマーを停止します。
+
+## 最適化
+
+参照作業のParametricFace最適化結果を踏まえ、30fps相当、固定レイアウト、26.6精度への量子化、変更部品のみ更新、旧・新boundsの部分invalidateを採用しました。部品は左右それぞれ虹彩・マスク・まぶた＋まつ毛・眉、および口です。入力不変なら点生成を省略し、描画も要求しません。
+
+Moddable 9.5.0の公式`Outline.clone(destination)`で、9個の不変な基準Outlineを10個の描画用Outlineへコピーしてから平行移動・拡縮します。描画用Outlineと10個のShapeは起動時に確保し、`fillOutline`は一度だけ設定します。口の上下は基準線に対する倍率がわずかに異なるため、同じ口Outlineを上下2個のShapeへ割り当てて基準線でクリップします。これにより現行の非対称なcubic輪郭を保ちます。毎tickでPath、Outline、配列、TypedArrayを生成しません。
+
+Shapeに非公開APIを追加せず、最前面の透明なPiu Portから標準`Port.invalidate(x, y, width, height)`を呼び、背後のShapeをdirty領域だけ再描画します。まぶたのマスクは上端固定なので、下端が通過する帯だけをinvalidateします。大きなマスク全体、左右の間、画面全体を周期的に描き直しません。虹彩は瞬きだけでは更新されません。曲線はサンプリングした多数の線分ではなくcubicのfill輪郭を使います。
+
+汎用のばね・回転・376点の再計算を持つParametricFaceとは異なり、小さな固定モデルのためJSのままです。native一括化・スプライト化は追加していません。
+
+## CoreS3実測（2026-09-05）
+
+Moddable 9.5.0、ESP-IDF 6.1、M5Stack CoreS3（ESP32-S3 rev 0.2、240MHz）で顔単独のinstrumentビルドを測定しました。各区間18秒のうち先頭5個の1秒サンプルを除外し、残り13サンプルを集計しています。CPUはJitomeFace専用時間ではなく各コア全体の非idle率、FPSはLCD走査ではなくPiu/Pocoのフレーム送信数です。
+
+| 条件 | CPU0 平均／最大 | CPU1 平均／最大 | 描画FPS 平均（範囲） | Pixels/s 平均 | GC |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 静止 | 0.00%／0% | 4.00%／4% | 0.00 | 0 | 0 |
+| 同一FaceStateを30fps投入 | 0.08%／1% | 6.00%／6% | 0.00 | 0 | 0 |
+| 連続瞬き30fps | 0.46%／1% | 72.23%／73% | 29.08（28–30） | 90,947 | 0 |
+| 全パーツ連続更新30fps | 0.46%／1% | 88.54%／94% | 27.15（24–29） | 196,441 | 0 |
+
+静止入力の早期returnは有効で、FaceState配送だけなら描画を発生させません。連続瞬きはほぼ30fpsを維持しますが、更新コアの負荷は約72%です。左右開眼・4方向視線・口を毎フレーム同時に変える最悪ケースは更新コアが飽和し、平均27.15fpsまで下がりました。通常の自動瞬きは約2.8～5秒の静止区間を挟むため、連続瞬き区間は通常時の平均CPUを示すものではありません。
+
+解析区間内ではSlot使用量53,632 bytesが一定、Chunk使用量も各区間内で一定、GCは全区間0回でした。生ログと機械集計は`dist/jitome-face-benchmark/run.log`と`result.json`へ出力します。
+
+## ビルド
+
+公式Moddable SDK 9.5.0以降を使用します。SDKソースへの独自パッチは不要です。9.5.0時点の型定義は`clone(destination)`を宣言していないため、アプリ側のローカルinterfaceだけで差分を補います。
+
+```sh
+# 公式9.5.0 SDKのMODDABLE、mcconfigのPATH、ESP-IDF 6.1環境を設定しfirmware/で実行
+npm run test:jitome-face-render
+npm run build:m5stack_cores3
+npm run benchmark:jitome-face:build:cores3
+UPLOAD_PORT=/dev/ttyACM0 npm run benchmark:jitome-face:flash:cores3
+UPLOAD_PORT=/dev/ttyACM0 npm run benchmark:jitome-face:capture:cores3
+```
+
+新しいhost moduleを含むホスト更新が必要です。CoreS3単体用は`m5stack_cores3`で、サーボ付きの`m5stackchan_cores3`とは別です。9.5.0未満ではDrawerのジト目項目を表示せず、通常のFaceを維持します。`ui.type: "jitome"`を明示した場合はSDKバージョン不足を説明するエラーになります。
+
+以下は接続機器へ書き込む操作です。検証済みホストを用意してから、対象ポートを確認して実行します。
+
+```sh
+UPLOAD_PORT=/dev/ttyACM0 npm run deploy:m5stack_cores3
+```
+
+## 検証
+
+XS/Piuをheadless screenで実行し、公式`clone(destination)`の再利用、虹彩の不変性、完全閉眼、眉の下降、Outline／buffer identity、不変入力時の更新省略を検証します。16状態（閉眼・再開眼・左右別開眼・視線・口パク・白黒反転）について、部分再描画と強制全再描画のフレームバッファ全バイト一致を確認します。テスト生成物は`dist/jitome-face-render/`です。
+
+調整：左右の目一式を拡大後の座標で各4px中央へ寄せています。口の制御点中央を下向きに0.75px（曲線中央の変位約0.56px）曲げ、入力開口量に応じて開口高さを最大5%増やしました。

--- a/firmware/host/app/compose.ts
+++ b/firmware/host/app/compose.ts
@@ -15,6 +15,7 @@ import { type BatteryLevelReader, ChatStatusBar } from 'chat-status-bar'
 import type { DrawerButtonViewSpec } from 'drawer'
 import { DynamixelDriver } from 'dynamixel-driver'
 import IMU from 'imu'
+import { createJitomeFace } from 'jitome-face'
 import Led from 'led'
 import { M5StackChanServoDriver } from 'm5stackchan-servo-driver'
 import config from 'mc/config'
@@ -144,6 +145,7 @@ export function createStackchanContext(
   ])
   const uiControllers = new Map<string, (param: unknown) => RobotUI>([
     ['dog', (param) => createStackchanUI(new DogFace(), asUIOptions(param))],
+    ['jitome', (param) => createStackchanUI(createJitomeFace().content, asUIOptions(param))],
     ['simple', (param) => createStackchanUI(new SimpleFace(), asUIOptions(param))],
     [
       'image',

--- a/firmware/host/app/default-behavior/__tests__/face-init/app-behavior-stub.ts
+++ b/firmware/host/app/default-behavior/__tests__/face-init/app-behavior-stub.ts
@@ -1,5 +1,8 @@
 // Test-only type boundary for app-default-behavior/on-context-created.
 export interface StackchanAppBehavior {
-  // biome-ignore lint/suspicious/noExplicitAny: this stub isolates the test from the full app context dependency graph.
-  onContextCreated?: (robot: any, option?: unknown) => Promise<void> | void
+  onContextCreated?: (
+    // biome-ignore lint/suspicious/noExplicitAny: this stub isolates the test from the full app context dependency graph.
+    robot: any,
+    option: { config: { ui: { type?: unknown }; [domain: string]: unknown } },
+  ) => Promise<void> | void
 }

--- a/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
+++ b/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
@@ -1,5 +1,6 @@
 import { onContextCreated } from 'app-default-behavior/on-context-created'
 import { Emotion } from 'face-state'
+import { isJitomeFaceSupported } from 'jitome-face'
 import { assert, equal } from 'testing/assert'
 
 trace('=== default-mod face init test ===\n')
@@ -123,7 +124,7 @@ try {
     config: {
       wifi: {},
       driver: {},
-      ui: {},
+      ui: { type: isJitomeFaceSupported() ? 'jitome' : 'simple' },
       tts: {},
       ai: {},
       led: {},
@@ -137,11 +138,25 @@ try {
 
 equal(buttons[0]?.key, 'toggleFace', 'toggleFace button should be registered')
 equal(buttons[0]?.kind, 'choice', 'face selection should use an option menu')
-equal(buttons[0]?.value, 'simple', 'face selection should expose its current value')
-equal(buttons[0]?.options?.length, 3, 'face selection should expose every mode')
+equal(
+  buttons[0]?.value,
+  isJitomeFaceSupported() ? 'jitome' : 'simple',
+  'face selection should expose the configured mode',
+)
+const expectedFaceModes = isJitomeFaceSupported() ? ['simple', 'dog', 'image', 'jitome'] : ['simple', 'dog', 'image']
+equal(buttons[0]?.options?.length, expectedFaceModes.length, 'face selection should expose supported modes')
+equal(
+  buttons[0]?.options?.map((option) => option.value).join(','),
+  expectedFaceModes.join(','),
+  'face selection should preserve the mode order',
+)
 equal(drawerStates.length, 0, 'choice controls should not masquerade as binary toggles')
 equal(events[0]?.[0], 'onFaceMode', 'initial face mode should be distributed')
-equal(events[0]?.[1], 'simple', 'initial face mode should be simple')
+equal(
+  events[0]?.[1],
+  isJitomeFaceSupported() ? 'jitome' : 'simple',
+  'initial face mode should match the supported preference',
+)
 const handsButton = buttons.find((button) => button.key === 'handAnimation')
 equal(handsButton?.kind, 'choice', 'hands should be exposed as a hierarchical option menu')
 equal(handsButton?.value, 'none', 'hands should start with no animation')

--- a/firmware/host/app/default-behavior/on-context-created.ts
+++ b/firmware/host/app/default-behavior/on-context-created.ts
@@ -6,6 +6,7 @@ import { Emoticon, type EmoticonKey } from 'effects/emoticon'
 import { Emotion } from 'face-state'
 import { type HandAnimationName, isHandAnimationName } from 'hands'
 import type { MotionType } from 'imu'
+import { createJitomeFace, isJitomeFaceSupported } from 'jitome-face'
 import { localize } from 'localization'
 import config from 'mc/config'
 import type { Content as PiuContent } from 'piu/MC'
@@ -57,7 +58,7 @@ function errorMessage(error: unknown): string {
   return String(error)
 }
 
-export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreated']> = (robot) => {
+export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreated']> = (robot, options) => {
   const emotions: Emotion[] = [Emotion.HAPPY, Emotion.ANGRY, Emotion.SAD, Emotion.HOT, Emotion.SLEEPY, Emotion.NEUTRAL]
   const emotionOptions = [
     { value: String(Emotion.NEUTRAL), label: localize('drawer.emotion.neutral') },
@@ -161,7 +162,12 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
     }
   }
 
-  let faceMode: 'simple' | 'dog' | 'image' = 'simple'
+  type FaceMode = 'simple' | 'dog' | 'image' | 'jitome'
+  const faceModes: FaceMode[] = isJitomeFaceSupported()
+    ? ['simple', 'dog', 'image', 'jitome']
+    : ['simple', 'dog', 'image']
+  const configuredFace = options.config.ui.type
+  let faceMode: FaceMode = faceModes.includes(configuredFace as FaceMode) ? (configuredFace as FaceMode) : 'simple'
   let handAnimation: HandAnimationName = 'none'
   let cameraPreviewTimer: ReturnType<typeof Timer.set> | undefined
   const syncFaceMode = (
@@ -171,8 +177,12 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
   }
   const syncHandAnimation = () => robot.ui.setHandAnimation(handAnimation)
   const closeDrawer = () => robot.ui.closeDrawer()
-  const createCurrentFace = () =>
-    faceMode === 'dog' ? new DogFace({}) : faceMode === 'image' ? new ImageFace({}) : new SimpleFace({})
+  const createCurrentFace = () => {
+    if (faceMode === 'dog') return new DogFace({})
+    if (faceMode === 'image') return new ImageFace({})
+    if (faceMode === 'jitome') return createJitomeFace().content
+    return new SimpleFace({})
+  }
   const restoreCameraPreview = () => {
     if (cameraPreviewTimer) {
       Timer.clear(cameraPreviewTimer)
@@ -187,14 +197,10 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
     label: localize('drawer.face'),
     kind: 'choice',
     value: faceMode,
-    options: [
-      { value: 'simple', label: localize('drawer.face.simple') },
-      { value: 'dog', label: localize('drawer.face.dog') },
-      { value: 'image', label: localize('drawer.face.image') },
-    ],
+    options: faceModes.map((value) => ({ value, label: localize(`drawer.face.${value}`) })),
     callback: (target, value) => {
-      if (value !== 'simple' && value !== 'dog' && value !== 'image') return
-      faceMode = value
+      if (!faceModes.includes(value as FaceMode)) return
+      faceMode = value as FaceMode
       target.ui.setFace(createCurrentFace())
       const app = target.ui.application as { distribute?: (event: string, payload: unknown) => void } | undefined
       syncFaceMode(app)

--- a/firmware/host/app/strings/en.json
+++ b/firmware/host/app/strings/en.json
@@ -75,6 +75,7 @@
   "drawer.face.simple": "Simple",
   "drawer.face.dog": "Dog",
   "drawer.face.image": "Image",
+  "drawer.face.jitome": "Jitome",
   "drawer.emotion": "Expression",
   "drawer.balloon": "Speech Bubble",
   "drawer.camera": "Camera",

--- a/firmware/host/app/strings/ja.json
+++ b/firmware/host/app/strings/ja.json
@@ -75,6 +75,7 @@
   "drawer.face.simple": "シンプル",
   "drawer.face.dog": "いぬ",
   "drawer.face.image": "画像",
+  "drawer.face.jitome": "ジト目",
   "drawer.emotion": "表情",
   "drawer.balloon": "吹き出し",
   "drawer.camera": "カメラ",

--- a/firmware/host/app/strings/zh-CN.json
+++ b/firmware/host/app/strings/zh-CN.json
@@ -75,6 +75,7 @@
   "drawer.face.simple": "简洁",
   "drawer.face.dog": "狗",
   "drawer.face.image": "图像",
+  "drawer.face.jitome": "Jitome",
   "drawer.emotion": "表情",
   "drawer.balloon": "气泡",
   "drawer.camera": "摄像头",

--- a/firmware/host/modules/ui/components/face/jitome/__tests__/jitome-face-render/main.js
+++ b/firmware/host/modules/ui/components/face/jitome/__tests__/jitome-face-render/main.js
@@ -1,0 +1,61 @@
+import { createFaceState } from 'face-state'
+import { createJitomeFace } from 'jitome-face'
+import 'piu/MC'
+
+function check(value, message) {
+  if (!value) throw new Error(message)
+}
+const face = createJitomeFace(),
+  b = face.content.behavior,
+  state = createFaceState()
+b.setMotionsEnabled(face.content, false)
+const iris = b.geometry.points[0].slice(),
+  outlines = b.outlines.slice(),
+  bases = b.bases.slice(),
+  buffers = b.geometry.points.slice()
+check(b.bases[0].clone(b.outlines[0]) === b.outlines[0], 'Outline.clone(destination) must reuse its destination')
+state.eyes.left.open = state.eyes.right.open = 0
+b.onFaceUpdate(face.content, state)
+for (let i = 0; i < iris.length; i++) check(iris[i] === b.geometry.points[0][i], 'blink moved iris')
+check(b.geometry.points[1][5] > b.geometry.points[0][7], 'closed lid must cover iris')
+check(b.geometry.points[3][1] === 98.625, 'brow must descend three device pixels')
+for (let i = 0; i < 10; i++) check(outlines[i] === b.outlines[i], 'outline allocation identity')
+for (let i = 0; i < 9; i++)
+  check(bases[i] === b.bases[i] && buffers[i] === b.geometry.points[i], 'geometry allocation identity')
+state.eyes.left.open = state.eyes.right.open = 1
+b.onFaceUpdate(face.content, state)
+check(b.geometry.update(1, 1, 0, 0, 0, 0, 0) === 0, 'unchanged face must skip updates')
+trace('GEOMETRY PASS\n')
+let step = 0
+export default new Application(null, {
+  skin: new Skin({ fill: 'black' }),
+  contents: [face.content],
+  Behavior: class extends Behavior {
+    onDisplaying(app) {
+      app.interval = 35
+      app.start()
+    }
+    onTimeChanged(app) {
+      if (step === 32) {
+        app.stop()
+        trace('RENDER COMPLETE\n')
+        return
+      }
+      const i = step >> 1
+      if (!(step & 1)) {
+        state.eyes.left.open = [1, 0.75, 0.5, 0.25, 0, 0.25, 0.75, 1][i % 8]
+        state.eyes.right.open = i < 8 ? state.eyes.left.open : 1 - state.eyes.left.open
+        state.eyes.left.gazeX = i < 8 ? 0 : i & 1 ? -1 : 1
+        state.eyes.right.gazeY = i < 8 ? 0 : i & 1 ? 1 : -1
+        state.mouth.open = i < 8 ? 0 : (i % 4) / 3
+        if (i === 12) {
+          state.theme.primary.r = state.theme.primary.g = state.theme.primary.b = 0
+          state.theme.secondary.r = state.theme.secondary.g = state.theme.secondary.b = 255
+        }
+        b.onFaceUpdate(face.content, state)
+        b.invalidator.invalidate(0, 0, 1, 1)
+      } else b.invalidator.invalidate(0, 0, 320, 240)
+      step++
+    }
+  },
+})

--- a/firmware/host/modules/ui/components/face/jitome/__tests__/jitome-face-render/manifest.json
+++ b/firmware/host/modules/ui/components/face/jitome/__tests__/jitome-face-render/manifest.json
@@ -1,0 +1,15 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "$(MODDABLE)/examples/manifest_piu.json",
+    "../../manifest.json"
+  ],
+  "modules": {
+    "main": "./main",
+    "face-state": "../../../../../state/face-state",
+    "face-skin": "../../../../../state/face-skin"
+  },
+  "config": { "startupSound": false },
+  "creation": { "stack": 1024 }
+}

--- a/firmware/host/modules/ui/components/face/jitome/geometry.ts
+++ b/firmware/host/modules/ui/components/face/jitome/geometry.ts
@@ -1,0 +1,165 @@
+/** Approved 320x240 preview, in device pixels. All buffers live for the face lifetime. */
+export const TOPOLOGY = ['MCC', 'MLLL', 'MCLC MCLC', 'MCLC', 'MCC', 'MLLL', 'MCLC MCLC', 'MCLC', 'MCC']
+const COUNTS = [7, 4, 16, 8, 7, 4, 16, 8, 7]
+const unit = (n: number, fallback: number) => (Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : fallback)
+const gaze = (n: number) => (Number.isFinite(n) ? Math.max(-1, Math.min(1, n)) : 0)
+export class JitomeGeometry {
+  readonly points = COUNTS.map((count) => new Float32Array(count * 2))
+  readonly previous = COUNTS.map((count) => new Float32Array(count * 2).fill(NaN))
+  readonly bounds = new Int32Array(36)
+  readonly dirty = new Int32Array(36)
+  private initialized = false
+  private readonly input = new Float64Array(7).fill(NaN)
+  private ribbon(p: Float32Array, o: number, x1: number, y1: number, x2: number, y2: number, t: number, bend = 0) {
+    const dx = (x2 - x1) / 3
+    p[o++] = x1
+    p[o++] = y1 - t / 2
+    p[o++] = x1 + dx
+    p[o++] = y1 + bend - t / 2
+    p[o++] = x2 - dx
+    p[o++] = y2 + bend - t / 2
+    p[o++] = x2
+    p[o++] = y2 - t / 2
+    p[o++] = x2
+    p[o++] = y2 + t / 2
+    p[o++] = x2 - dx
+    p[o++] = y2 + bend + t / 2
+    p[o++] = x1 + dx
+    p[o++] = y1 + bend + t / 2
+    p[o++] = x1
+    p[o] = y1 + t / 2
+  }
+  private eye(id: number, cx: number, side: number, open: number, gx: number, gy: number) {
+    const blink = 1 - unit(open, 1),
+      rx = 15.99,
+      top = 131.25
+    const height = 31.9 * (1 + gaze(gy) * 0.08),
+      bottom = top + height
+    const x = cx + gaze(gx) * 3.895,
+      shoulder = top + height * 0.84
+    let p = this.points[id]
+    p[0] = x - rx
+    p[1] = top
+    p[2] = x - rx
+    p[3] = shoulder
+    p[4] = x - rx * 0.65
+    p[5] = bottom
+    p[6] = x
+    p[7] = bottom
+    p[8] = x + rx * 0.65
+    p[9] = bottom
+    p[10] = x + rx
+    p[11] = shoulder
+    p[12] = x + rx
+    p[13] = top
+    const cy = 127 + (height + 1) * blink
+    p = this.points[id + 1]
+    p[0] = cx - 32.5
+    p[1] = 55
+    p[2] = cx + 32.5
+    p[3] = 55
+    p[4] = cx + 32.5
+    p[5] = cy + 4.25
+    p[6] = cx - 32.5
+    p[7] = cy + 4.25
+    p = this.points[id + 2]
+    this.ribbon(p, 0, cx - 20.5, cy, cx + 20.5, cy, 4.5)
+    this.ribbon(p, 16, cx + side * 18.5, cy, cx + side * 24.5, cy - 2.2, 3.15)
+    this.ribbon(this.points[id + 3], 0, cx - 12.71, 112.5 + 2 * blink, cx + 12.71, 112.5 + 2 * blink, 1.5, -0.5)
+  }
+  /** Returns a changed-part bitmask. Eye open=1 is the approved half-lidded neutral face. */
+  update(
+    leftOpen: number,
+    rightOpen: number,
+    leftX: number,
+    leftY: number,
+    rightX: number,
+    rightY: number,
+    mouthOpen: number,
+  ) {
+    const input = this.input
+    if (
+      input[0] === leftOpen &&
+      input[1] === rightOpen &&
+      input[2] === leftX &&
+      input[3] === leftY &&
+      input[4] === rightX &&
+      input[5] === rightY &&
+      input[6] === mouthOpen
+    )
+      return 0
+    input[0] = leftOpen
+    input[1] = rightOpen
+    input[2] = leftX
+    input[3] = leftY
+    input[4] = rightX
+    input[5] = rightY
+    input[6] = mouthOpen
+    this.eye(0, 102.5 + 4 / 1.5, -1, leftOpen, leftX, leftY)
+    this.eye(4, 217.5 - 4 / 1.5, 1, rightOpen, rightX, rightY)
+    const p = this.points[8],
+      y = 174,
+      open = unit(mouthOpen, 0),
+      h = (0.9 + (0.14 + 0.86 * open) * 12) * 0.67 * (1 + 0.05 * open)
+    p[0] = 154
+    p[1] = y
+    p[2] = 154
+    p[3] = y + 0.5 - h
+    p[4] = 166
+    p[5] = y + 0.5 - h
+    p[6] = 166
+    p[7] = y
+    p[8] = 166
+    p[9] = y + 0.5 + h
+    p[10] = 154
+    p[11] = y + 0.5 + h
+    p[12] = 154
+    p[13] = y
+    let mask = 0
+    for (let id = 0; id < 9; id++) {
+      const points = this.points[id],
+        previous = this.previous[id],
+        o = id * 4
+      let changed = false,
+        x = Infinity,
+        y = Infinity,
+        right = -Infinity,
+        bottom = -Infinity
+      const oldMaskBottom = previous[5]
+      for (let i = 0; i < points.length; i += 2) {
+        const px = Math.round((160 + (points[i] - 160) * 1.5) * 64) / 64
+        const py = Math.round((144 + (points[i + 1] - 144) * 1.5) * 64) / 64
+        points[i] = px
+        points[i + 1] = py
+        if (px !== previous[i] || py !== previous[i + 1]) changed = true
+        previous[i] = px
+        previous[i + 1] = py
+        x = Math.min(x, px)
+        y = Math.min(y, py)
+        right = Math.max(right, px)
+        bottom = Math.max(bottom, py)
+      }
+      if (!changed) continue
+      mask |= 1 << id
+      x = Math.floor(x) - 1
+      y = Math.floor(y) - 1
+      right = Math.ceil(right) + 1
+      bottom = Math.ceil(bottom) + 1
+      this.dirty[o] = this.initialized ? Math.min(x, this.bounds[o]) : x
+      this.dirty[o + 1] = this.initialized ? Math.min(y, this.bounds[o + 1]) : y
+      this.dirty[o + 2] = (this.initialized ? Math.max(right, this.bounds[o + 2]) : right) - this.dirty[o]
+      this.dirty[o + 3] = (this.initialized ? Math.max(bottom, this.bounds[o + 3]) : bottom) - this.dirty[o + 1]
+      // Only the moving lower edge changes this fixed-width mask, not its entire area.
+      if (this.initialized && (id === 1 || id === 5)) {
+        this.dirty[o + 1] = Math.floor(Math.min(oldMaskBottom, points[5])) - 1
+        this.dirty[o + 3] = Math.ceil(Math.max(oldMaskBottom, points[5])) + 1 - this.dirty[o + 1]
+      }
+      this.bounds[o] = x
+      this.bounds[o + 1] = y
+      this.bounds[o + 2] = right
+      this.bounds[o + 3] = bottom
+    }
+    this.initialized = true
+    return mask
+  }
+}

--- a/firmware/host/modules/ui/components/face/jitome/jitome-face.ts
+++ b/firmware/host/modules/ui/components/face/jitome/jitome-face.ts
@@ -1,0 +1,242 @@
+import { Outline } from 'commodetto/outline'
+import { type FaceSkinPalette, updateFaceSkinPalette } from 'face-skin'
+import { copyFaceState, createFaceState, type FaceState } from 'face-state'
+import { JitomeGeometry, TOPOLOGY } from 'jitome-face/geometry'
+import { Container, type Container as PiuContainer, type Port as PiuPort, Port } from 'piu/MC'
+import type { Shape as PiuShape } from 'piu/shape'
+import 'piu/shape'
+
+interface ReusableOutline extends Outline {
+  readonly byteLength: number
+  clone(destination?: Outline): Outline
+}
+
+const OUTLINE_PARTS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 8]
+const MOUTH_BASELINE = 189
+let reusableOutlineSupport: boolean | undefined
+
+/** Whether the active Moddable SDK can render the built-in Jitome face. */
+export function isJitomeFaceSupported(): boolean {
+  if (reusableOutlineSupport !== undefined) return reusableOutlineSupport
+  try {
+    const source = Outline.fill(Outline.PolygonPath(0, 0, 2, 0, 0, 2)) as ReusableOutline
+    const destination = source.clone() as ReusableOutline
+    reusableOutlineSupport =
+      source.clone(destination) === destination && typeof (Port.prototype as PiuPort).invalidate === 'function'
+  } catch {
+    reusableOutlineSupport = false
+  }
+  return reusableOutlineSupport
+}
+
+class JitomeBehavior extends Behavior {
+  readonly breathPixels = 0
+  readonly preservePositionOnSwap = false
+  readonly desired = createFaceState()
+  readonly geometry = new JitomeGeometry()
+  readonly references: Float32Array[] = []
+  readonly bases: ReusableOutline[] = []
+  readonly shapes: PiuShape[] = []
+  readonly outlines: ReusableOutline[] = []
+  readonly base = { left: 0, top: 0 }
+  invalidator: PiuPort | null = null
+  palette: FaceSkinPalette | null = null
+  enabled = true
+  displayed = false
+  paused = false
+  elapsed = 0
+  nextBlink = 2800
+  blinkTime = -1
+  lastTime = 0
+  onCreate(content: PiuContainer) {
+    content.interval = 33
+  }
+  private createPath(id: number) {
+    const path = new Outline.FreeTypePath(),
+      points = this.geometry.points[id]
+    let offset = 0
+    for (const contour of TOPOLOGY[id].split(' ')) {
+      for (const command of contour) {
+        if (command === 'M') path.beginSubpath(points[offset++], points[offset++])
+        else if (command === 'L') path.lineTo(points[offset++], points[offset++])
+        else
+          path.cubicTo(
+            points[offset++],
+            points[offset++],
+            points[offset++],
+            points[offset++],
+            points[offset++],
+            points[offset++],
+          )
+      }
+      path.endSubpath()
+    }
+    if (offset !== points.length) throw new Error('JitomeFace: unexpected Outline topology')
+    return path
+  }
+  private transformOutline(index: number) {
+    const id = OUTLINE_PARTS[index],
+      points = this.geometry.points[id],
+      reference = this.references[id],
+      destination = this.outlines[index],
+      outline = this.bases[id].clone(destination) as ReusableOutline
+    if (outline !== destination) throw new Error('JitomeFace requires Moddable SDK 9.5.0 or later')
+    if (id === 0 || id === 4) {
+      const scale = (points[7] - points[1]) / (reference[7] - reference[1])
+      outline
+        .translate(0, -reference[1])
+        .scale(1, scale)
+        .translate(points[6] - reference[6], reference[1])
+    } else if (id === 1 || id === 5) {
+      const scale = (points[5] - points[1]) / (reference[5] - reference[1])
+      outline.translate(0, -reference[1]).scale(1, scale).translate(0, reference[1])
+    } else if (id === 2 || id === 3 || id === 6 || id === 7) {
+      outline.translate(0, points[1] - reference[1])
+    } else if (index === 8) {
+      const scale = (points[3] - points[1]) / (reference[3] - reference[1])
+      outline.translate(0, -MOUTH_BASELINE).scale(1, scale).translate(0, MOUTH_BASELINE)
+    } else {
+      const scale = (points[9] - points[7]) / (reference[9] - reference[7])
+      outline.translate(0, -MOUTH_BASELINE).scale(1, scale)
+    }
+  }
+  attach(content: PiuContainer) {
+    this.geometry.update(1, 1, 0, 0, 0, 0, 0)
+    for (let id = 0; id < TOPOLOGY.length; id++) {
+      this.references.push(this.geometry.points[id].slice())
+      this.bases.push(Outline.fill(this.createPath(id)) as ReusableOutline)
+    }
+    for (let index = 0; index < OUTLINE_PARTS.length; index++) {
+      const id = OUTLINE_PARTS[index],
+        outline = this.bases[id].clone() as ReusableOutline,
+        lowerMouth = index === 9,
+        shape = new Shape(null, {
+          left: 0,
+          top: lowerMouth ? MOUTH_BASELINE : 0,
+          width: 320,
+          height: lowerMouth ? 240 - MOUTH_BASELINE : index === 8 ? MOUTH_BASELINE : 240,
+        }) as PiuShape
+      this.outlines.push(outline)
+      if (lowerMouth) this.transformOutline(index)
+      shape.fillOutline = outline
+      this.shapes.push(shape)
+      content.add(shape)
+    }
+    this.invalidator = new Port(null, { left: 0, top: 0, width: 320, height: 240 }) as PiuPort
+    content.add(this.invalidator)
+    this.applySkin(content, updateFaceSkinPalette(null, this.desired))
+  }
+  applySkin(content: PiuContainer, palette: FaceSkinPalette) {
+    if (palette === this.palette) return
+    this.palette = palette
+    content.skin = palette.secondary
+    for (let i = 0; i < this.shapes.length; i++)
+      this.shapes[i].skin = i === 1 || i === 5 ? palette.secondary : palette.primary
+  }
+  onFaceSkin(content: PiuContainer, palette: FaceSkinPalette) {
+    this.applySkin(content, palette)
+  }
+  onFaceUpdate(content: PiuContainer, state: FaceState) {
+    copyFaceState(state, this.desired)
+    this.applySkin(content, updateFaceSkinPalette(this.palette, state))
+    if (!this.enabled && !this.paused) this.render(1)
+  }
+  onFaceState(content: PiuContainer, state: FaceState) {
+    this.onFaceUpdate(content, state)
+  }
+  rehydrate(content: PiuContainer, state: FaceState, palette?: FaceSkinPalette | null) {
+    this.onFaceUpdate(content, state)
+    if (palette) this.applySkin(content, palette)
+    this.lastTime = content.time
+    this.render(1)
+  }
+  onDisplaying(content: PiuContainer) {
+    this.displayed = true
+    this.lastTime = content.time
+    this.render(1)
+    if (this.enabled && !this.paused) content.start()
+  }
+  onUndisplaying(content: PiuContainer) {
+    this.displayed = false
+    content.stop()
+  }
+  onTimeChanged(content: PiuContainer) {
+    if (!this.enabled || this.paused || !this.displayed) return
+    const dt = Math.max(0, Math.min(100, content.time - this.lastTime))
+    this.lastTime = content.time
+    this.elapsed += dt
+    let openness = 1
+    if (this.blinkTime < 0 && this.elapsed >= this.nextBlink) this.blinkTime = 0
+    if (this.blinkTime >= 0) {
+      this.blinkTime += dt
+      const t = this.blinkTime
+      // Close, hold fully shut, then reopen. No gaze motion is injected during a blink.
+      openness = t < 90 ? 1 - t / 90 : t < 135 ? 0 : Math.min(1, (t - 135) / 200)
+      if (t >= 335) {
+        this.blinkTime = -1
+        this.nextBlink = this.elapsed + 2800 + Math.random() * 2200
+      }
+    }
+    this.render(openness)
+  }
+  render(openness: number) {
+    const state = this.desired,
+      left = state.eyes.left,
+      right = state.eyes.right
+    const changed = this.geometry.update(
+      left.open * openness,
+      right.open * openness,
+      left.gazeX,
+      left.gazeY,
+      right.gazeX,
+      right.gazeY,
+      state.mouth.open,
+    )
+    for (let index = 0; index < OUTLINE_PARTS.length; index++)
+      if (changed & (1 << OUTLINE_PARTS[index])) this.transformOutline(index)
+    for (let id = 0; id < 9; id++) {
+      if (!(changed & (1 << id)) || !this.invalidator) continue
+      const o = id * 4,
+        d = this.geometry.dirty
+      this.invalidator.invalidate(d[o], d[o + 1], d[o + 2], d[o + 3])
+    }
+  }
+  getBaseCoordinates(content: PiuContainer) {
+    this.base.left = content.coordinates.left ?? 0
+    this.base.top = content.coordinates.top ?? 0
+    return this.base
+  }
+  setMotionsEnabled(content: PiuContainer, enabled: boolean) {
+    this.enabled = enabled
+    this.blinkTime = -1
+    this.lastTime = content.time
+    if (enabled && this.displayed && !this.paused) content.start()
+    else content.stop()
+    if (!this.paused) this.render(1)
+  }
+  pause(content: PiuContainer) {
+    this.paused = true
+    content.stop()
+    content.visible = false
+    content.active = false
+  }
+  resume(content: PiuContainer) {
+    this.paused = false
+    content.visible = true
+    content.active = true
+    this.lastTime = content.time
+    this.render(1)
+    if (this.enabled && this.displayed) content.start()
+  }
+  onTouchEnded(content: PiuContainer) {
+    content.bubble('onFaceTouch')
+  }
+}
+/** CoreS3 320x240 face matching the approved preview. No lower eyelid or body motion. */
+export function createJitomeFace(): { readonly content: PiuContainer } {
+  if (!isJitomeFaceSupported()) throw new Error('JitomeFace requires Moddable SDK 9.5.0 or later')
+  const behavior = new JitomeBehavior()
+  const content = new Container(null, { left: 0, top: 0, width: 320, height: 240, clip: true, active: true, behavior })
+  behavior.attach(content)
+  return { content }
+}

--- a/firmware/host/modules/ui/components/face/jitome/manifest.json
+++ b/firmware/host/modules/ui/components/face/jitome/manifest.json
@@ -1,0 +1,10 @@
+{
+  "include": [
+    "$(MODDABLE)/modules/commodetto/outline/manifest.json",
+    "$(MODDABLE)/modules/piu/MC/outline/manifest.json"
+  ],
+  "modules": {
+    "jitome-face": "./jitome-face",
+    "jitome-face/geometry": "./geometry"
+  }
+}

--- a/firmware/host/modules/ui/manifest.json
+++ b/firmware/host/modules/ui/manifest.json
@@ -7,7 +7,8 @@
     "$(MODDABLE)/modules/piu/MC/outline/manifest.json",
     "$(MODDABLE)/modules/piu/MC/qrcode/manifest.json",
     "$(MODULES)/commodetto/outline/manifest.json",
-    "../util/manifest.json"
+    "../util/manifest.json",
+    "./components/face/jitome/manifest.json"
   ],
   "modules": {
     "app-controller": "./application/app-controller",

--- a/firmware/host/modules/ui/views/main/__tests__/face-view-state/face-view-state.test.ts
+++ b/firmware/host/modules/ui/views/main/__tests__/face-view-state/face-view-state.test.ts
@@ -3,6 +3,7 @@ import { FaceBehavior } from 'behaviors/face'
 import type { StackchanContext } from 'capabilities'
 import { SpeechBalloon } from 'effects/speech-balloon'
 import { createFaceState, type FaceState, setColorRGB, toPiuColorNumber } from 'face-state'
+import { createJitomeFace, isJitomeFaceSupported } from 'jitome-face'
 import {
   Application,
   Container,
@@ -572,4 +573,18 @@ equal(rightHand.visible, true, 'thinking animation should keep the chin-side han
 assert(rightHand.y > initialThinkingTop, 'thinking should move the chin-side point sprite')
 controller.setHandAnimation('none')
 handsBehavior.onUndisplaying?.(hands)
+// Full-screen faces must not inherit the legacy 60px origin on an actual UI swap.
+if (isJitomeFaceSupported()) {
+  const jitome = createJitomeFace().content
+  controller.setFace(jitome)
+  equal(nodeCoordinate(faceRegion, 'left') + nodeCoordinate(jitome, 'left'), 0, 'Jitome screen origin x')
+  equal(nodeCoordinate(faceRegion, 'top') + nodeCoordinate(jitome, 'top'), 0, 'Jitome screen origin y')
+  equal(nodeCoordinate(faceRegion, 'width'), 320, 'Jitome full screen clip width')
+  equal(nodeCoordinate(faceRegion, 'height'), 240, 'Jitome full screen clip height')
+  controller.setFace(nextFace)
+  controller.setFace(jitome)
+  equal(nodeCoordinate(faceRegion, 'left') + nodeCoordinate(jitome, 'left'), 0, 'Repeated swap origin x')
+  equal(nodeCoordinate(faceRegion, 'top') + nodeCoordinate(jitome, 'top'), 0, 'Repeated swap origin y')
+  controller.setFaceMotionEnabled(false)
+}
 trace('ok\n')

--- a/firmware/host/modules/ui/views/main/face-view.ts
+++ b/firmware/host/modules/ui/views/main/face-view.ts
@@ -36,6 +36,8 @@ type DieRegion = PiuContainer & { set: (x: number, y: number, w: number, h: numb
 export type FaceViewBaseCoordinates = { left: number; top: number }
 export type FaceViewCustomFaceBehavior = {
   readonly breathPixels?: number
+  /** False uses the incoming face coordinates instead of inheriting the outgoing origin. */
+  readonly preservePositionOnSwap?: boolean
   onFaceUpdate?: (container: PiuContainer, face: FaceState) => void
   rehydrate?: (container: PiuContainer, face: FaceState, palette?: FaceSkinPalette | null) => void
   getBaseCoordinates?: (container: PiuContainer) => FaceViewBaseCoordinates
@@ -293,7 +295,12 @@ class FaceViewBehavior extends CommonViewBehavior {
       ? (((currentFace as PiuContent & { container?: PiuContainer }).container ??
           this.faceRegion) as PiuContainer | null)
       : null
-    const currentCoordinates = currentFace ? this.getFaceVisualCoordinates(currentFace) : null
+    const currentCoordinates =
+      faceBehavior(face)?.preservePositionOnSwap === false
+        ? readFaceBaseCoordinates(face)
+        : currentFace
+          ? this.getFaceVisualCoordinates(currentFace)
+          : null
     this.face = face
     this.prepareFaceForRegion(face, currentCoordinates)
     faceBehavior(face)?.setMotionsEnabled?.(face, this.faceMotionEnabled)

--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.10",
         "@google-cloud/text-to-speech": "^6.4.1",
-        "@moddable/typings": "^9.0.1",
+        "@moddable/typings": "^9.5.0",
         "cross-env": "^10.1.0",
         "fontkit": "^2.0.2",
         "lefthook": "^2.1.10",
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/@moddable/typings": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-9.0.1.tgz",
-      "integrity": "sha512-9oyPxCJCadPLLRDzm4n7GWlseaXryVqJFQa4rBWw/tTVGm6Yiw8B7fYCEl6PMB4tIOlBKtQ6/uCuHuo5rN/21A==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-9.5.0.tgz",
+      "integrity": "sha512-t58DSpWp1XigNiN6xpfhEAK4/erm5OmDUATQ35i+bpu0bhJuLS8Pc1yu5D9SSNRZEurhhYS6ZR2NP+HXPTJKRg==",
       "dev": true,
       "license": "ISC"
     },

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -4,6 +4,11 @@
   "description": "A firmware of M5Stack Stack-chan module",
   "main": "host/app/main.ts",
   "scripts": {
+    "test:jitome-face-render": "node scripts/test-jitome-face-render.mjs",
+    "test:jitome-face-render:build": "node scripts/run-mcconfig.mjs -dn -m -p lin/m5stack -t build host/modules/ui/components/face/jitome/__tests__/jitome-face-render/manifest.json",
+    "benchmark:jitome-face:build:cores3": "node scripts/run-mcconfig.mjs -i -m -p esp32/m5stack_cores3 -t build benchmarks/jitome-face/manifest.json",
+    "benchmark:jitome-face:capture:cores3": "node scripts/capture-jitome-face-benchmark.mjs",
+    "benchmark:jitome-face:flash:cores3": "node scripts/run-mcconfig.mjs -i -m -p esp32/m5stack_cores3 -t deploy benchmarks/jitome-face/manifest.json",
     "format": "biome format host mods scripts",
     "format:fix": "npm run format -- --write",
     "lint": "biome lint host mods scripts",
@@ -54,6 +59,7 @@
     "bundle": "node scripts/bundle.mjs",
     "bundle:package": "node scripts/package-bundle.mjs",
     "deploy": "node scripts/firmware.mjs deploy",
+    "deploy:m5stack_cores3": "node scripts/run-mcconfig.mjs -m -p esp32/m5stack_cores3 -t deploy \"$PWD/host/app/manifest_local.json\"",
     "deploy:m5stackchan_cores3": "node scripts/firmware.mjs deploy m5stackchan_cores3",
     "deploy:stackchan_rt": "node scripts/firmware.mjs deploy stackchan_rt",
     "deploy:takao_core2_sg90": "node scripts/firmware.mjs deploy takao_core2_sg90",
@@ -107,7 +113,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.10",
     "@google-cloud/text-to-speech": "^6.4.1",
-    "@moddable/typings": "^9.0.1",
+    "@moddable/typings": "^9.5.0",
     "cross-env": "^10.1.0",
     "fontkit": "^2.0.2",
     "lefthook": "^2.1.10",

--- a/firmware/scripts/capture-jitome-face-benchmark.mjs
+++ b/firmware/scripts/capture-jitome-face-benchmark.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { SerialPort } from 'serialport'
+import { buildOutputDirectory } from './lib/build-output.mjs'
+
+const serialPath = process.env.UPLOAD_PORT ?? '/dev/ttyACM0'
+const baudRate = 460800
+const discardedSamples = 5
+const outputDirectory = path.join(buildOutputDirectory, 'jitome-face-benchmark')
+const logLines = []
+const samples = new Map()
+const phaseResults = new Map()
+let keys = []
+let currentPhase = null
+let buffer = ''
+let finished = false
+
+function metric(sample, name) {
+  return Number(sample[name] ?? 0)
+}
+
+function statistics(values) {
+  if (!values.length) return { mean: 0, min: 0, max: 0 }
+  const total = values.reduce((sum, value) => sum + value, 0)
+  return {
+    mean: Math.round((total / values.length) * 100) / 100,
+    min: Math.min(...values),
+    max: Math.max(...values),
+  }
+}
+
+function summarize() {
+  const phases = {}
+  for (const [name, allSamples] of samples) {
+    const kept = allSamples.slice(discardedSamples)
+    phases[name] = {
+      samples: allSamples.length,
+      analyzedSamples: kept.length,
+      cpu0: statistics(kept.map((sample) => metric(sample, 'CPU 0'))),
+      cpu1: statistics(kept.map((sample) => metric(sample, 'CPU 1'))),
+      framesPerSecond: statistics(kept.map((sample) => metric(sample, 'Frames drawn'))),
+      pixelsPerSecond: statistics(kept.map((sample) => metric(sample, 'Pixels drawn'))),
+      garbageCollections: statistics(kept.map((sample) => metric(sample, 'Garbage collections'))),
+      chunkUsed: statistics(kept.map((sample) => metric(sample, 'Chunk used'))),
+      slotUsed: statistics(kept.map((sample) => metric(sample, 'Slot used'))),
+      workload: phaseResults.get(name) ?? null,
+    }
+  }
+  return { serialPath, baudRate, discardedSamples, phases }
+}
+
+function processLine(line, complete) {
+  line = line.replace(/\r$/, '')
+  logLines.push(line)
+  console.log(line)
+  if (line.startsWith('instruments key: ')) {
+    keys = line.slice('instruments key: '.length).split(',')
+  } else if (line.startsWith('instruments: ') && currentPhase && keys.length) {
+    const values = line.slice('instruments: '.length).split(',')
+    const sample = Object.fromEntries(keys.map((key, index) => [key, Number(values[index])]))
+    samples.get(currentPhase).push(sample)
+  } else if (line.startsWith('[JITOME-BENCH] phase=')) {
+    currentPhase = line.slice('[JITOME-BENCH] phase='.length)
+    if (!samples.has(currentPhase)) samples.set(currentPhase, [])
+  } else if (line.startsWith('[JITOME-BENCH] result phase=')) {
+    const match = /phase=([^ ]+) elapsed=(\d+) ticks=(\d+) updates=(\d+)/.exec(line)
+    if (match)
+      phaseResults.set(match[1], {
+        elapsed: Number(match[2]),
+        ticks: Number(match[3]),
+        updates: Number(match[4]),
+      })
+  } else if (line === '[JITOME-BENCH] complete') {
+    currentPhase = null
+    setTimeout(complete, 250)
+  }
+}
+
+function resetDevice() {
+  const python = process.env.ESP_IDF_PYTHON ?? 'python3'
+  const program = [
+    'import serial, sys, time',
+    `port = serial.Serial(sys.argv[1], ${baudRate}, timeout=0.2)`,
+    'port.dtr = False',
+    'port.rts = True',
+    'time.sleep(0.01)',
+    'port.rts = False',
+    'port.close()',
+  ].join('\n')
+  const result = spawnSync(python, ['-c', program, serialPath], { encoding: 'utf8' })
+  if (result.status !== 0)
+    throw new Error(`CoreS3 reset failed. Activate the ESP-IDF environment or set ESP_IDF_PYTHON.\n${result.stderr}`)
+}
+
+async function main() {
+  mkdirSync(outputDirectory, { recursive: true })
+  const port = new SerialPort({ path: serialPath, baudRate })
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('JitomeFace benchmark timed out')), 120000)
+    const complete = () => {
+      if (finished) return
+      finished = true
+      clearTimeout(timeout)
+      resolve()
+    }
+    port.on('data', (data) => {
+      buffer += data.toString('utf8')
+      let end = buffer.indexOf('\n')
+      while (end >= 0) {
+        processLine(buffer.slice(0, end), complete)
+        buffer = buffer.slice(end + 1)
+        end = buffer.indexOf('\n')
+      }
+    })
+    port.on('error', reject)
+  })
+  await new Promise((resolve) => port.close(resolve))
+  const result = summarize()
+  writeFileSync(path.join(outputDirectory, 'run.log'), `${logLines.join('\n')}\n`)
+  writeFileSync(path.join(outputDirectory, 'result.json'), `${JSON.stringify(result, null, 2)}\n`)
+  console.log(`[JITOME-BENCH] summary ${JSON.stringify(result)}`)
+}
+
+try {
+  resetDevice()
+  await main()
+} catch (error) {
+  console.error(error.message)
+  process.exitCode = 1
+}

--- a/firmware/scripts/jitome-face-screen.c
+++ b/firmware/scripts/jitome-face-screen.c
@@ -1,0 +1,68 @@
+/* Headless host for the mcsim screen ABI. Test-only, never included in firmware. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include "screen.h"
+
+static double interval;
+static gint64 deadline;
+static int frames;
+static const char *output;
+static void noop(txScreen *screen) { (void)screen; }
+static void changed(txScreen *screen) {
+  uint32_t hash = 2166136261u;
+  for (int i = 0; i < screen->width * screen->height * 4; i++) hash = (hash ^ screen->buffer[i]) * 16777619u;
+  printf("FRAME %08x\n", hash);
+  if (frames < 64) {
+    char path[4096];
+    snprintf(path, sizeof(path), "%s/frame-%03d.rgba", output, frames);
+    FILE *file = fopen(path, "wb");
+    if (!file) exit(2);
+    fwrite(screen->buffer, 1, screen->width * screen->height * 4, file);
+    fclose(file);
+  }
+  frames++;
+}
+static void start(txScreen *screen, double ms) {
+  (void)screen; interval = ms; deadline = g_get_monotonic_time() + (gint64)(ms * 1000);
+}
+static void stop(txScreen *screen) { (void)screen; interval = 0; }
+static void abortScreen(txScreen *screen, int status) {
+  (void)screen; fprintf(stderr, "SIMULATOR ABORT %d\n", status); exit(1);
+}
+static void post(txScreen *screen, char *message, int size) { (void)screen; (void)message; (void)size; }
+static gboolean tick(gpointer data) {
+  txScreen *screen = data;
+  if (interval && g_get_monotonic_time() >= deadline) {
+    deadline = g_get_monotonic_time() + (gint64)(interval * 1000);
+    screen->idle(screen);
+  }
+  return G_SOURCE_CONTINUE;
+}
+static gboolean finish(gpointer loop) { g_main_loop_quit(loop); return G_SOURCE_REMOVE; }
+int main(int argc, char **argv) {
+  if (argc != 3 && argc != 4) return 2;
+  output = argv[2];
+  void *library = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+  if (!library) { fprintf(stderr, "%s\n", dlerror()); return 2; }
+  txScreenLaunchProc launch = (txScreenLaunchProc)dlsym(library, "fxScreenLaunch");
+  if (!launch) return 2;
+  txScreen *screen = calloc(1, sizeof(txScreen) + 320 * 240 * 4);
+  if (!screen) return 2;
+  screen->width = 320; screen->height = 240;
+  screen->abort = abortScreen; screen->bufferChanged = changed;
+  screen->formatChanged = noop; screen->start = start; screen->stop = stop; screen->post = post;
+  mxCreateMutex(&screen->workersMutex);
+  launch(screen);
+  GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+  guint timer = g_timeout_add(1, tick, screen);
+  g_timeout_add_seconds(argc == 4 ? atoi(argv[3]) : 4, finish, loop);
+  g_main_loop_run(loop);
+  g_source_remove(timer);
+  if (screen->quit) screen->quit(screen);
+  g_main_loop_unref(loop);
+  mxDeleteMutex(&screen->workersMutex);
+  free(screen); dlclose(library);
+  return 0;
+}

--- a/firmware/scripts/test-jitome-face-render.mjs
+++ b/firmware/scripts/test-jitome-face-render.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { buildOutputDirectory } from './lib/build-output.mjs'
+
+const sdk = process.env.MODDABLE
+assert.ok(sdk, 'Set MODDABLE to Moddable SDK 9.5.0 or later')
+const directory = path.join(buildOutputDirectory, 'jitome-face-render')
+mkdirSync(directory, { recursive: true })
+function run(command, args, options = {}) {
+  const r = spawnSync(command, args, { encoding: 'utf8', maxBuffer: 20000000, ...options })
+  assert.equal(r.status, 0, r.stdout + r.stderr)
+  return r.stdout + r.stderr
+}
+const flags = run('pkg-config', ['--cflags', '--libs', 'glib-2.0']).trim().split(/\s+/)
+const runner = path.join(directory, 'screen-runner')
+run('cc', [
+  '-DmxLinux=1',
+  '-Wall',
+  '-Wextra',
+  '-Werror',
+  `-I${sdk}/build/simulators/modules`,
+  'scripts/jitome-face-screen.c',
+  '-o',
+  runner,
+  ...flags,
+  '-ldl',
+])
+writeFileSync(path.join(directory, 'build.log'), run('npm', ['run', 'test:jitome-face-render:build']))
+const log = run(
+  runner,
+  [path.join(buildOutputDirectory, 'bin/lin/m5stack/debug/jitome-face-render/mc.so'), directory],
+  { env: { ...process.env, XSBUG_HOST: '127.0.0.1', XSBUG_PORT: '5099' }, timeout: 15000 },
+)
+writeFileSync(path.join(directory, 'render.log'), log)
+assert.ok(log.includes('GEOMETRY PASS') && log.includes('RENDER COMPLETE'), log)
+const frames = [...log.matchAll(/^FRAME ([0-9a-f]+)$/gm)]
+assert.equal(frames.length, 33, log)
+for (let i = 0; i < 16; i++) {
+  const load = (n) => readFileSync(path.join(directory, `frame-${String(n).padStart(3, '0')}.rgba`))
+  assert.ok(load(1 + i * 2).equals(load(2 + i * 2)), `partial redraw ${i} differs from full redraw`)
+}
+assert.ok(new Set(frames.map((f) => f[1])).size >= 10, 'distinct blink, gaze, mouth, and theme images')
+console.log(
+  'PASS: stationary iris, full closure, brow descent, stable allocations, unchanged-frame skip; 16 partial/full framebuffer pairs',
+)

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -18,6 +18,8 @@
     "sourceMap": true,
     "target": "es2024",
     "paths": {
+      "jitome-face": ["./host/modules/ui/components/face/jitome/jitome-face"],
+      "jitome-face/geometry": ["./host/modules/ui/components/face/jitome/geometry"],
       "face-state": [
         "./host/modules/ui/state/face-state"
       ],

--- a/firmware/typings/xs-runtime.d.ts
+++ b/firmware/typings/xs-runtime.d.ts
@@ -1,5 +1,4 @@
-// @moddable/typings 9.0.0 omits the xs.d.ts entry declared by its package.json.
-// Keep the XS extensions used by Stack-chan available to standalone TypeScript checks.
+// Keep XS host extensions used by Stack-chan available to standalone TypeScript checks.
 
 declare function trace(...messages: (string | number | boolean)[]): void
 


### PR DESCRIPTION
## Release impact\n\nminor\n\n## 概要

M5Stack CoreS3向けに、ジト目と小さな口を持つ単色のJitomeFaceを追加します。Drawerから選択でき、`ui.type: "jitome"`による起動時指定にも対応します。標準のSimple Faceは変更しません。

## 必要環境

**Moddable SDK 9.5.0以降が必要です。**

9.5.0で追加された公式の`Outline.clone(destination)`を使用して描画用Outlineを再利用します。Moddable SDK側への独自パッチは不要です。9.5.0未満ではJitomeFaceをDrawerの選択肢に表示せず、明示指定時には要件を示すエラーにします。

この要件に合わせて、firmwareの型定義とCI／release buildで使用するModdableを9.5.0へ更新します。

## 実装

- 左右別の開眼量、視線、口パク、テーマ色に対応
- 33ms間隔の自動瞬きとFace motion停止／再開に対応
- 不変な基準Outline 9個と描画用Outline 10個を起動時に確保
- 毎tickのPath、Outline、配列、TypedArray生成を回避
- 標準`Port.invalidate()`による変更部品だけの部分再描画
- 全画面Face交換時に旧Faceの座標を引き継がないレイアウト対応
- headless描画回帰テストとCoreS3向けinstrument benchmarkを追加

## CoreS3実測

Moddable 9.5.0、ESP-IDF 6.1、ESP32-S3 rev 0.2／240MHzで測定しました。各18秒区間の先頭5サンプルを除外しています。

| 条件 | CPU1 平均／最大 | 描画FPS平均 | Pixels/s平均 | GC |
| --- | ---: | ---: | ---: | ---: |
| 静止 | 4.00%／4% | 0.00 | 0 | 0 |
| 同一FaceStateを30fps投入 | 6.00%／6% | 0.00 | 0 | 0 |
| 連続瞬き30fps | 72.23%／73% | 29.08 | 90,947 | 0 |
| 全パーツ連続更新30fps | 88.54%／94% | 27.15 | 196,441 | 0 |

通常の自動瞬きは約2.8〜5秒の静止区間を挟むため、連続瞬きは通常利用時の平均負荷ではなく、連続更新時の負荷です。

## 検証

- [x] `npm run lint`
- [x] `npm run check:manifest`（6ターゲット）
- [x] `npm run test:unit`（404件）
- [x] `npm run test:jitome-face-render`
  - 16状態で部分再描画と強制全再描画のフレームバッファが一致
  - 静止虹彩、完全閉眼、眉下降、allocation identity、不変入力の描画省略を確認
- [x] M5Stack CoreS3 release build
- [x] M5Stack CoreS3への書き込みと起動確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the Jitome (glaring-eye) face for M5Stack CoreS3.
  - Supports blinking, gaze control, mouth movement, themes, touch interaction, and motion controls.
  - Added Jitome to the face selection menu when supported by the device software.
  - Added localized face labels in English, Japanese, and Simplified Chinese.
  - Face replacement now supports correct positioning and full-screen display.

- **Documentation**
  - Added usage, behavior, build, rendering, and performance documentation.

- **Tests**
  - Added rendering validation and CoreS3 performance benchmarks for the new face.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->