### PR TITLE
fix: serialize SCServo bus transactions and recover malformed responses

### DIFF
--- a/.changeset/quiet-servo-bus.md
+++ b/.changeset/quiet-servo-bus.md
@@ -3,3 +3,5 @@
 ---
 
 Serialize SCServo transactions across both axes, preserve recovery delays after missing responses, and recover packet synchronization after malformed input. Attempt torque release on both axes even if one axis fails, while reporting the failure to the caller.
+
+Check buffered UART replies before declaring a command timeout when UI or audio work delays readable callbacks.

--- a/.changeset/quiet-servo-bus.md
+++ b/.changeset/quiet-servo-bus.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Serialize SCServo transactions across both axes, preserve recovery delays after missing responses, and recover packet synchronization after malformed input. Attempt torque release on both axes even if one axis fails, while reporting the failure to the caller.

--- a/firmware/host/modules/motion/__tests__/scservo-bus/fake-power.js
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/fake-power.js
@@ -1,0 +1,3 @@
+export function tryGetSharedPY32IOExpander() {
+  throw new Error('servo power must be disabled in this test')
+}

--- a/firmware/host/modules/motion/__tests__/scservo-bus/fake-serial.js
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/fake-serial.js
@@ -1,0 +1,25 @@
+export default class FakeSerial {
+  static instance
+  writes = []
+  incoming = []
+  failures = 0
+  constructor(options) {
+    this.options = options
+    this.format = options.format
+    FakeSerial.instance = this
+  }
+  write(bytes) {
+    if (this.failures > 0) {
+      this.failures--
+      throw new Error('serial write failed')
+    }
+    this.writes.push(Uint8Array.from(bytes))
+  }
+  read() {
+    return this.incoming.shift()
+  }
+  inject(bytes) {
+    this.incoming.push(...bytes)
+    this.options.onReadable.call(this, bytes.length)
+  }
+}

--- a/firmware/host/modules/motion/__tests__/scservo-bus/manifest.test.json
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/manifest.test.json
@@ -1,5 +1,6 @@
 {
   "include": [
+    "../../scservo-manifest.json",
     "$(MODDABLE)/examples/manifest_base.json",
     "$(MODDABLE)/examples/manifest_typings.json",
     "../../../testing/manifest.json"
@@ -8,10 +9,6 @@
     "main": "./scservo-bus.test",
     "embedded:io/serial": "./fake-serial",
     "timer": "$(MODDABLE)/modules/base/timer/*",
-    "protocols/scservo": "../../protocols/scservo",
-    "single-wait-slot": "../../internal/single-wait-slot",
-    "servo-command-error": "../../internal/servo-command-error",
-    "payload-buffer": "../../payload-buffer",
     "m5stackchan-servo": "../../m5stackchan-servo",
     "m5stackchan-servo-driver": "../../m5stackchan-servo-driver",
     "scservo-driver": "../../scservo-driver",

--- a/firmware/host/modules/motion/__tests__/scservo-bus/manifest.test.json
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/manifest.test.json
@@ -1,0 +1,34 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../testing/manifest.json"
+  ],
+  "modules": {
+    "main": "./scservo-bus.test",
+    "embedded:io/serial": "./fake-serial",
+    "timer": "$(MODDABLE)/modules/base/timer/*",
+    "protocols/scservo": "../../protocols/scservo",
+    "single-wait-slot": "../../internal/single-wait-slot",
+    "servo-command-error": "../../internal/servo-command-error",
+    "payload-buffer": "../../payload-buffer",
+    "m5stackchan-servo": "../../m5stackchan-servo",
+    "m5stackchan-servo-driver": "../../m5stackchan-servo-driver",
+    "scservo-driver": "../../scservo-driver",
+    "motion-controller": "../../motion-controller",
+    "stackchan-util": "../../../util/stackchan-util",
+    "mac-address": "../../../util/sim/mac-address",
+    "py32-io-expander": "./fake-power"
+  },
+  "strip": [],
+  "typescript": {
+    "tsconfig": {
+      "compilerOptions": {
+        "noImplicitAny": false,
+        "strictNullChecks": false,
+        "strictPropertyInitialization": false,
+        "strictFunctionTypes": false
+      }
+    }
+  }
+}

--- a/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
@@ -1,10 +1,8 @@
-import Serial from 'embedded:io/serial'
-import * as SerialNamespace from 'embedded:io/serial'
-import * as TimerNamespace from 'testing/fakes/timer'
+import Serial, * as SerialNamespace from 'embedded:io/serial'
 import * as ConfigNamespace from 'mc/config'
-import Timer from 'testing/fakes/timer'
-import NativeTimer from 'timer'
 import { assert, equal } from 'testing/assert'
+import Timer, * as TimerNamespace from 'testing/fakes/timer'
+import NativeTimer from 'timer'
 
 const modules = {
   timer: { namespace: TimerNamespace },

--- a/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
@@ -45,9 +45,14 @@ function runTest() {
   const tilt = new SCServo({ id: 2 })
   const serial = Serial.instance
   let completed = 0
+  // Noise received while idle can leave a syntactically valid partial frame.
+  // Neither it nor an unread old ACK may settle or corrupt the next command.
+  serial.inject([255, 255, 1, 8, 0])
+  serial.incoming.push(...response(1))
   pan.setTorque(true, () => tilt.setTorque(true, () => completed++))
   pan.readRawPosition(() => completed++)
   equal(serial.writes.length, 1, 'only the first command is on the bus')
+  equal(completed, 0, 'buffered stale ACK cannot settle the new command')
   ack(1)
   equal(serial.writes.length, 2, 'one queued command starts after ACK')
   equal(last()[4], 2, 'FIFO keeps the already queued read before the chained tilt write')

--- a/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
@@ -1,0 +1,156 @@
+import Serial from 'embedded:io/serial'
+import * as SerialNamespace from 'embedded:io/serial'
+import * as TimerNamespace from 'testing/fakes/timer'
+import * as ConfigNamespace from 'mc/config'
+import Timer from 'testing/fakes/timer'
+import NativeTimer from 'timer'
+import { assert, equal } from 'testing/assert'
+
+const modules = {
+  timer: { namespace: TimerNamespace },
+  'embedded:io/serial': { namespace: SerialNamespace },
+  'mc/config': { namespace: ConfigNamespace },
+}
+for (const name of [
+  'protocols/scservo',
+  'single-wait-slot',
+  'servo-command-error',
+  'payload-buffer',
+  'm5stackchan-servo',
+  'm5stackchan-servo-driver',
+  'scservo-driver',
+  'motion-controller',
+  'stackchan-util',
+  'mac-address',
+  'py32-io-expander',
+])
+  modules[name] = { source: name }
+const compartment = new Compartment({ globals: { trace }, modules, resolveHook: (name) => name })
+const SCServo = compartment.importNow('protocols/scservo').default
+const { M5StackChanServoDriver } = compartment.importNow('m5stackchan-servo-driver')
+const { SCServoDriver } = compartment.importNow('scservo-driver')
+
+function response(id, payload = []) {
+  const body = [id, payload.length + 2, 0, ...payload]
+  return [255, 255, ...body, ~body.reduce((a, b) => a + b, 0) & 255]
+}
+function ack(id, payload) {
+  Serial.instance.inject(response(id, payload))
+  Timer.advance(0)
+}
+function last() {
+  return Serial.instance.writes.at(-1)
+}
+
+function runTest() {
+  const pan = new SCServo({ id: 1 })
+  const tilt = new SCServo({ id: 2 })
+  const serial = Serial.instance
+  let completed = 0
+  pan.setTorque(true, () => tilt.setTorque(true, () => completed++))
+  pan.readRawPosition(() => completed++)
+  equal(serial.writes.length, 1, 'only the first command is on the bus')
+  ack(1)
+  equal(serial.writes.length, 2, 'one queued command starts after ACK')
+  equal(last()[4], 2, 'FIFO keeps the already queued read before the chained tilt write')
+  serial.inject(response(1))
+  equal(serial.writes.length, 2, 'write ACK cannot settle a read')
+  ack(1, [0, 10])
+  equal(last()[2], 2, 'tilt starts after pan read response')
+  equal(completed, 1, 'only pan read is complete')
+  ack(2)
+  equal(completed, 2, 'both operations completed')
+
+  pan.setTorque(true, () => completed++)
+  serial.inject([0, ...response(1).slice(0, 3)])
+  serial.inject(response(1).slice(3))
+  Timer.advance(0)
+  equal(completed, 3, 'one noise byte followed by a split ACK is accepted')
+  pan.setTorque(false, () => completed++)
+  serial.inject([255, 255, 255, ...response(1).slice(2)])
+  Timer.advance(0)
+  equal(completed, 4, 'extra header byte does not lose synchronization')
+
+  for (const length of [0, 1, 61, 255]) {
+    pan.setTorque(false, () => completed++)
+    serial.inject([255, 255, 1, length, ...response(1)])
+    Timer.advance(0)
+  }
+  equal(completed, 8, 'invalid lengths cannot trap the parser')
+  pan.setTorque(false, () => completed++)
+  const broken = response(1)
+  broken[broken.length - 1] ^= 1
+  serial.inject([...broken, ...response(2), ...response(1)])
+  Timer.advance(0)
+  equal(completed, 9, 'checksum and wrong-ID responses are ignored')
+
+  let timeouts = 0
+  pan.setTorque(true, (error) => {
+    assert(error != null, 'missing ACK reports an error')
+    timeouts++
+    tilt.setTorque(false, () => completed++)
+  })
+  const beforeTimeout = serial.writes.length
+  Timer.advance(120)
+  equal(timeouts, 1, 'timeout fires once')
+  equal(serial.writes.length, beforeTimeout, 'callback cannot bypass recovery')
+  serial.inject(response(1))
+  Timer.advance(19)
+  equal(serial.writes.length, beforeTimeout, 'recovery still owns the bus')
+  Timer.advance(1)
+  equal(serial.writes.length, beforeTimeout + 1, 'queued command starts after recovery')
+  ack(2)
+  equal(completed, 10, 'late ACK did not settle the next operation')
+
+  // flashId changes the instance ID before a queued ID write is dispatched.
+  // Its packet must still target the old ID, accepting ACKs at either ID.
+  for (const ackAtNewId of [false, true]) {
+    const oldId = pan.id
+    const newId = oldId + 10
+    let changed = false
+    pan.flashId(newId, (error) => {
+      assert(error == null, 'ID change succeeds')
+      changed = true
+    })
+    ack(oldId)
+    equal(last()[2], oldId, 'queued ID write targets old ID')
+    equal(last()[5], 5, 'ID write register')
+    ack(ackAtNewId ? newId : oldId)
+    equal(last()[2], newId, 'lock targets new ID')
+    ack(newId)
+    assert(changed, 'flashId callback settles')
+  }
+
+  // Preserve the existing retry for Serial.write throwing (not ACK timeout).
+  serial.failures = 1
+  tilt.setTorque(true, () => completed++)
+  Timer.advance(1)
+  ack(2)
+  equal(completed, 11, 'write exception retry remains supported')
+  pan.teardown()
+  tilt.teardown()
+
+  for (const [Driver, panId] of [
+    [M5StackChanServoDriver, 40],
+    [SCServoDriver, 42],
+  ]) {
+    const driver = new Driver({
+      panId,
+      tiltId: panId + 1,
+      servoPower: { type: 'none' },
+      serial: { port: 2, receive: 16, transmit: 17 },
+    })
+    let result
+    driver.setTorque(false, (error) => {
+      result = error
+    })
+    equal(last()[2], panId, 'release begins with pan')
+    Timer.advance(120)
+    Timer.advance(20)
+    equal(last()[2], panId + 1, 'tilt OFF is attempted despite pan timeout')
+    ack(panId + 1)
+    assert(result != null, 'original OFF failure is preserved')
+  }
+  trace('ok\n')
+}
+NativeTimer.set(runTest, 100)

--- a/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
+++ b/firmware/host/modules/motion/__tests__/scservo-bus/scservo-bus.test.js
@@ -84,6 +84,20 @@ function runTest() {
   Timer.advance(0)
   equal(completed, 9, 'checksum and wrong-ID responses are ignored')
 
+  // A received ACK must win even if XS dispatches the timeout timer before
+  // the queued Serial.onReadable callback.
+  let bufferedCompleted = 0
+  pan.setTorque(false, (error) => {
+    assert(error == null, 'buffered ACK settles the write before timeout')
+    bufferedCompleted++
+  })
+  serial.incoming.push(...response(1))
+  Timer.advance(120)
+  equal(bufferedCompleted, 1, 'already received ACK is accepted')
+  serial.inject([])
+  equal(bufferedCompleted, 1, 'delayed readable event cannot complete twice')
+  Timer.advance(0)
+
   let timeouts = 0
   pan.setTorque(true, (error) => {
     assert(error != null, 'missing ACK reports an error')

--- a/firmware/host/modules/motion/m5stackchan-servo-driver.ts
+++ b/firmware/host/modules/motion/m5stackchan-servo-driver.ts
@@ -79,11 +79,11 @@ export class M5StackChanServoDriver {
 
   setTorque(torque: boolean, callback?: MotionCompletion): void {
     this.#pan.setTorque(torque, (panError) => {
-      if (panError != null) {
+      if (panError != null && torque) {
         callback?.(panError)
         return
       }
-      this.#tilt.setTorque(torque, callback)
+      this.#tilt.setTorque(torque, (tiltError) => callback?.(panError ?? tiltError))
     })
   }
 

--- a/firmware/host/modules/motion/manifest.json
+++ b/firmware/host/modules/motion/manifest.json
@@ -4,7 +4,8 @@
     "$(MODDABLE)/examples/manifest_typings.json",
     "$(MODDABLE)/modules/io/manifest.json",
     "../util/manifest.json",
-    "../io-expander/manifest.json"
+    "../io-expander/manifest.json",
+    "./scservo-manifest.json"
   ],
   "modules": {
     "*": ["./*", "./internal/*"],

--- a/firmware/host/modules/motion/protocols/scservo.ts
+++ b/firmware/host/modules/motion/protocols/scservo.ts
@@ -207,6 +207,12 @@ class PacketHandler extends Serial {
     const dispatch = this.#queue.shift()
     if (!dispatch) return
     this.#busy = true
+    // Idle/startup noise and delayed replies belong to the previous transaction.
+    // Discard them before installing a new command's response waiter.
+    this.#recovering = true
+    this.poll()
+    this.resetReceiver()
+    this.#recovering = false
     dispatch()
   }
 }

--- a/firmware/host/modules/motion/protocols/scservo.ts
+++ b/firmware/host/modules/motion/protocols/scservo.ts
@@ -75,12 +75,17 @@ class PacketHandler extends Serial {
   #idx: number
   #state: RxState
   #count: number
+  #queue: (() => void)[] = []
+  #busy = false
+  #recovering = false
   constructor(option) {
     const onReadable = function (this: PacketHandler, byte: number) {
       const rxBuf = this.#rxBuffer
       for (let b = 0; b < byte; b++) {
+        const value = this.read() as number
+        if (this.#recovering) continue
         // NOTE: We can safely read a number
-        rxBuf[this.#idx++] = this.read() as number
+        rxBuf[this.#idx++] = value
         switch (this.#state) {
           case RX_STATE.SEEK:
             if (this.#idx >= 2) {
@@ -91,14 +96,23 @@ class PacketHandler extends Serial {
               } else {
                 // reset seek
                 // trace('seeking failed. reset\n')
-                this.#idx = 0
+                this.#idx = value === 0xff ? 1 : 0
+                rxBuf[0] = value
               }
             }
             break
           case RX_STATE.HEAD:
+            if (this.#idx === 3 && value === 0xff) {
+              this.#idx = 2
+              break
+            }
             if (this.#idx >= 4) {
               this.#count = rxBuf[3]
-              this.#state = RX_STATE.BODY
+              if (this.#count < 2 || this.#count > rxBuf.length - 4) {
+                this.resetReceiver()
+              } else {
+                this.#state = RX_STATE.BODY
+              }
             }
             break
           case RX_STATE.BODY:
@@ -108,20 +122,20 @@ class PacketHandler extends Serial {
               const cs = checksum(rxBuf, this.#idx - 1) & 0xff
               const id = rxBuf[2]
               const command = rxBuf[4] as Command
+              const packetLength = this.#idx
+              this.resetReceiver()
               if (command === COMMAND.READ || command === COMMAND.WRITE) {
                 // trace(`got echo.  ... ${rxBuf.subarray(0, this.#idx)} ignoring\n`)
-              } else if (cs === rxBuf[this.#idx - 1] && this.#callbacks.has(id)) {
+              } else if (cs === rxBuf[packetLength - 1] && this.#callbacks.has(id)) {
                 // trace(`got response for ${id}. triggering callback \n`)
-                const payloadLength = this.#idx - 6
+                const payloadLength = packetLength - 6
                 const payloadView = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 5)
                 const payload = new Uint8Array(payloadLength)
                 payload.set(payloadView.subarray(0, payloadLength))
                 this.#callbacks.get(id)(payload, payloadLength)
               } else {
-                trace(`unknown packet for ${id} ... ${rxBuf.subarray(0, this.#idx)}. ignoring\n`)
+                trace(`unknown packet for ${id} ... ${rxBuf.subarray(0, packetLength)}. ignoring\n`)
               }
-              this.#idx = 0
-              this.#state = RX_STATE.SEEK
             }
             break
           default: {
@@ -150,6 +164,41 @@ class PacketHandler extends Serial {
   }
   removeCallback(id: number) {
     this.#callbacks.delete(id)
+  }
+
+  resetReceiver(): void {
+    this.#idx = 0
+    this.#state = RX_STATE.SEEK
+    this.#count = 0
+  }
+
+  enqueue(dispatch: () => void): void {
+    this.#queue.push(dispatch)
+    this.#drain()
+  }
+
+  // Keep the bus reserved before invoking user callbacks, including callbacks
+  // which synchronously enqueue a command for a different servo.
+  release(recover: boolean): void {
+    this.#recovering = recover
+    this.resetReceiver()
+    Timer.set(
+      () => {
+        this.resetReceiver()
+        this.#recovering = false
+        this.#busy = false
+        this.#drain()
+      },
+      recover ? COMMAND_RECOVERY_DELAY_MS : 0,
+    )
+  }
+
+  #drain(): void {
+    if (this.#busy) return
+    const dispatch = this.#queue.shift()
+    if (!dispatch) return
+    this.#busy = true
+    dispatch()
   }
 }
 
@@ -182,13 +231,6 @@ type CommandCallback = (values: Uint8Array | undefined) => void
 type ErrorCallback = (error: unknown) => void
 type CompletionCallback = (error?: unknown) => void
 type ResultCallback<T> = (result: Maybe<T>) => void
-type PendingCommand = {
-  command: Command
-  address: Address
-  onResult: CommandCallback
-  onError: ErrorCallback
-  values: number[]
-}
 const COMMAND_BUSY_ERROR = 'command is already waiting for response'
 const COMMAND_TIMEOUT_MS = 120
 const COMMAND_RECOVERY_DELAY_MS = 20
@@ -226,7 +268,7 @@ class SCServo {
   #onCommandRead: (buffer: Uint8Array, length: number) => void
   #txBuf: Uint8Array
   #waitSlot: SingleWaitSlot<Uint8Array>
-  #commandQueue: PendingCommand[] = []
+  #responseLength = 0
   #offset: number
   #awaitWriteResponse: boolean
   #isWriting = false
@@ -235,8 +277,8 @@ class SCServo {
     this.#waitSlot = new SingleWaitSlot<Uint8Array>(Timer.set, Timer.clear)
     this.#offset = 0
     this.#awaitWriteResponse = awaitWriteResponse
-    this.#onCommandRead = (values, _length) => {
-      this.#waitSlot.resolve(values)
+    this.#onCommandRead = (values, length) => {
+      if (length === this.#responseLength) this.#waitSlot.resolve(values)
     }
     this.#txBuf = new Uint8Array(64)
     const serial = serialOverride ?? config.serial ?? {}
@@ -272,6 +314,7 @@ class SCServo {
   }
 
   #dispatchCommand(
+    id: number,
     command: Command,
     address: Address,
     onResult: CommandCallback,
@@ -284,9 +327,10 @@ class SCServo {
       return false
     }
     this.#isWriting = true
+    this.#responseLength = command === COMMAND.READ ? values[0] : 0
     this.#txBuf[0] = 0xff
     this.#txBuf[1] = 0xff
-    this.#txBuf[2] = this.#id
+    this.#txBuf[2] = id
     this.#txBuf[3] = values.length + 3
     this.#txBuf[4] = command // write or read
     this.#txBuf[5] = address
@@ -307,19 +351,16 @@ class SCServo {
           return
         }
         const waiting = this.#waitSlot.wait(COMMAND_TIMEOUT_MS, onResult, () => {
-          trace(`[scservo] timeout id=${this.#id} command=${command} address=${address}\n`)
+          trace(`[scservo] timeout id=${id} command=${command} address=${address}\n`)
           onError(new CommandTimeoutError('scservo', COMMAND_TIMEOUT_MS))
         })
         if (!waiting) {
           onError(new Error(COMMAND_BUSY_ERROR))
-        } else {
-          Timer.set(this.#drainCommandQueue, 0)
         }
       },
       (error) => {
         this.#isWriting = false
         onError(error)
-        Timer.set(this.#drainCommandQueue, 0)
       },
     )
     return true
@@ -358,34 +399,31 @@ class SCServo {
     onError: ErrorCallback,
     ...values: number[]
   ): boolean {
-    this.#commandQueue.push({ command, address, onResult, onError, values })
-    this.#drainCommandQueue()
+    const id = this.#id
+    packetHandler.enqueue(() => {
+      let settled = false
+      const finish = (error?: unknown, result?: Uint8Array) => {
+        if (settled) return
+        settled = true
+        packetHandler.release(error instanceof CommandTimeoutError)
+        if (error !== undefined) onError(error)
+        else onResult(result)
+      }
+      try {
+        this.#dispatchCommand(
+          id,
+          command,
+          address,
+          (result) => finish(undefined, result),
+          (error) => finish(error),
+          ...values,
+        )
+      } catch (error) {
+        if (settled) throw error
+        finish(error)
+      }
+    })
     return true
-  }
-
-  #drainCommandQueue = (): void => {
-    if (this.#isWriting || this.#waitSlot.isWaiting) return
-    const pending = this.#commandQueue.shift()
-    if (pending == null) return
-    this.#dispatchCommand(
-      pending.command,
-      pending.address,
-      (values) => {
-        try {
-          pending.onResult(values)
-        } finally {
-          Timer.set(this.#drainCommandQueue, 0)
-        }
-      },
-      (error) => {
-        try {
-          pending.onError(error)
-        } finally {
-          Timer.set(this.#drainCommandQueue, error instanceof CommandTimeoutError ? COMMAND_RECOVERY_DELAY_MS : 0)
-        }
-      },
-      ...pending.values,
-    )
   }
 
   #lock(callback?: CompletionCallback): void {

--- a/firmware/host/modules/motion/protocols/scservo.ts
+++ b/firmware/host/modules/motion/protocols/scservo.ts
@@ -78,11 +78,13 @@ class PacketHandler extends Serial {
   #queue: (() => void)[] = []
   #busy = false
   #recovering = false
+  #readAvailable: (count: number) => void
   constructor(option) {
     const onReadable = function (this: PacketHandler, byte: number) {
       const rxBuf = this.#rxBuffer
       for (let b = 0; b < byte; b++) {
-        const value = this.read() as number
+        const value = this.read() as number | undefined
+        if (value === undefined) break
         if (this.#recovering) continue
         // NOTE: We can safely read a number
         rxBuf[this.#idx++] = value
@@ -150,12 +152,19 @@ class PacketHandler extends Serial {
       format: 'number',
       onReadable,
     })
+    this.#readAvailable = onReadable.bind(this)
     this.#callbacks = new Map<number, (buffer: Uint8Array, length: number) => void>()
     this.#rxBuffer = new Uint8Array(64)
     this.#payloadBuffer = new PayloadBuffer(32)
     this.#idx = 0
     this.#state = RX_STATE.SEEK
   }
+  poll(): void {
+    // Drain a bounded UART FIFO before timing out. The XS timer can run before
+    // an already posted Serial.onReadable callback under UI/audio load.
+    this.#readAvailable(128)
+  }
+
   hasCallbackOf(id: number): boolean {
     return this.#callbacks.has(id)
   }
@@ -274,7 +283,14 @@ class SCServo {
   #isWriting = false
   constructor({ id, awaitWriteResponse = true, serial: serialOverride }: SCServoConstructorParam) {
     this.#id = id
-    this.#waitSlot = new SingleWaitSlot<Uint8Array>(Timer.set, Timer.clear)
+    this.#waitSlot = new SingleWaitSlot<Uint8Array>(
+      (callback, timeout) =>
+        Timer.set(() => {
+          packetHandler.poll()
+          if (this.#waitSlot.isWaiting) callback()
+        }, timeout),
+      Timer.clear,
+    )
     this.#offset = 0
     this.#awaitWriteResponse = awaitWriteResponse
     this.#onCommandRead = (values, length) => {

--- a/firmware/host/modules/motion/scservo-driver.ts
+++ b/firmware/host/modules/motion/scservo-driver.ts
@@ -28,11 +28,11 @@ export class SCServoDriver {
 
   setTorque(torque: boolean, callback?: MotionCompletion): void {
     this._pan.setTorque(torque, (panError) => {
-      if (panError != null) {
+      if (panError != null && torque) {
         callback?.(panError)
         return
       }
-      this._tilt.setTorque(torque, callback)
+      this._tilt.setTorque(torque, (tiltError) => callback?.(panError ?? tiltError))
     })
   }
 

--- a/firmware/host/modules/motion/scservo-manifest.json
+++ b/firmware/host/modules/motion/scservo-manifest.json
@@ -1,0 +1,8 @@
+{
+  "modules": {
+    "protocols/scservo": "./protocols/scservo",
+    "single-wait-slot": "./internal/single-wait-slot",
+    "servo-command-error": "./internal/servo-command-error",
+    "payload-buffer": "./payload-buffer"
+  }
+}


### PR DESCRIPTION
SCServoの複数IDへの要求を共通キューで直列化し、タイムアウトからの復旧中に次の要求が割り込むことを防ぎます。外部動作の終了時には、片軸の失敗後も両軸のトルクOFFを試み、最初のエラーを呼び出し元へ返します。

追加で、タイムアウト判定の前にUARTの受信FIFOを処理します。ACKが到着済みでもonReadableの通知が遅れると失敗していたケースを修正しました。次の要求の開始前には、待機中に残ったバイトと部分フレームを破棄します。書き込みの自動再送や、失敗を成功扱いする処理は追加していません。

変更規模はpatchです。Changesetを含みます。SDK 9.5対応の #692 とは独立しています。

### 検証

- 単体テスト404件、アーキテクチャ検査78件、対象のBiome検査が通過。
- XSのfake Serial / Timerで、通知前に届いたACK、残存ACK、部分フレーム、タイムアウト復旧を検証。
- 最新CIはテスト、XS、smoke、web visual、全6機種のreleaseビルドと成果物生成が通過。成果物アップロードの一時的な403は失敗ジョブの再実行で解消。
- CoreS3 / SDK 9.5統合版の実機では、同一起動中に動作のみ20件、音声＋動作20件の計40件が連続成功。トルクOFFの中央値65 ms、最大213 ms。

### 残っている実機の問題

再起動後はACKの欠落・破損とタイムアウトが再発します。上記40件は再起動をまたぐ安定性を保証しません。サーボ電源の入れ直し、およびUARTの100 nsノイズフィルターも安定した改善にならず、試験変更は撤去しました。通信が破損する原因は未確定のため、Draftを維持します。

関連: meganetaaan/stack-chan-ai#94、#95。通常会話への割込み後も、トルク解除失敗を含む一連の動作の再検証が必要です。
