### PR TITLE
feat: share XiaoZhi audio between half-duplex and downlink modes

### DIFF
--- a/.changeset/shared-xiaozhi-output.md
+++ b/.changeset/shared-xiaozhi-output.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": minor
+---
+
+Add exclusive XiaoZhi turn control to ChatService. The default halfDuplex mode and the new downlink mode share the Worker decoder, bounded PCM ring, and audio output. Downlink does not allocate microphone resources or start listening. Unsupported fullDuplex fails before creating resources. Add local playback hooks with FIFO turn boundaries and cancellation-safe identities.

--- a/docs/architecture/xiaozhi-turn-control.md
+++ b/docs/architecture/xiaozhi-turn-control.md
@@ -1,0 +1,44 @@
+# XiaoZhi turn control
+
+`ChatService` accepts `turnControl: 'halfDuplex' | 'downlink' | 'fullDuplex'`.
+The default is `halfDuplex`; `fullDuplex` is reserved and throws before creating
+audio resources or a Worker. This is a local policy, not a XiaoZhi wire field.
+It is independent of the standard `listen.mode` setting.
+
+```js
+const peer = new ChatService({
+  connection: createXiaozhiV1Connection({ endpoint, accessToken, deviceId, clientId }),
+  turnControl: 'downlink',
+  tools,
+  callbacks,
+})
+peer.start()
+```
+
+The caller obtains credentials/tickets and chooses when to start, close, and
+reconnect. The transport socket lives inside the Worker, alongside the Opus
+decoder. Do not relay binary frames through a main-thread Promise queue.
+`ChatService.supportsProtocol('xiaozhi-v1', 2)` checks for this contract.
+
+Both XiaoZhi modes use the same audio engine. Downlink omits AudioIn, its input
+buffer and capture ring, the Opus encoder, and automatic listen commands. It
+stays connected after output drains. Hello, MCP results and other control
+messages remain bidirectional. Other ChatAudioIO providers retain their SDK
+implementation.
+
+The optional `onOutputTurnStarted(turn)` and `onOutputTurnEnded(turn)` callbacks
+are local playback hooks and may return promises. `turn.id` is local to the
+connection; `turn.isCurrent()` becomes false after interruption or completion.
+Use that predicate after asynchronous hardware work. A start hook gates output;
+an end hook gates the following turn. Tool calls for a queued turn are held until
+its start hook finishes. Keep hooks bounded and always clean up hardware when
+closing the service. The engine does not send proprietary playback ACKs.
+
+`tts.stop` marks the end of received audio, not immediate playback completion.
+PCM and turn boundaries are FIFO. Output levels are computed when AudioOut
+requests samples, not when packets arrive. The PCM ring bounds decoded audio;
+closing output wakes a producer waiting for ring space before Worker shutdown.
+
+The Host-owned XiaoZhi AudioIO base is derived from Moddable SDK 9.5 ChatAudioIO
+and retains its LGPL notice. Native codecs and the PCM ring implementation are
+provided by the Host; MODs do not need to add native code.

--- a/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
+++ b/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
@@ -16,9 +16,10 @@ import Timer from 'timer'
 
 trace('=== chat-service test ===\n')
 
-equal(ChatService.protocolContractVersion('xiaozhi-v1'), 1, 'host exposes the XiaoZhi contract version')
+equal(ChatService.protocolContractVersion('xiaozhi-v1'), 2, 'host exposes the turn-control contract version')
 equal(ChatService.supportsProtocol('xiaozhi-v1'), true, 'host reports XiaoZhi v1 support')
-equal(ChatService.supportsProtocol('xiaozhi-v1', 2), false, 'host rejects a newer required contract')
+equal(ChatService.supportsProtocol('xiaozhi-v1', 2), true, 'host supports downlink turn control')
+equal(ChatService.supportsProtocol('xiaozhi-v1', 3), false, 'host rejects a newer required contract')
 equal(ChatService.supportsProtocol('unknown'), false, 'host rejects unknown connection protocols')
 
 const tools: Record<string, ChatTool> = {
@@ -103,6 +104,18 @@ equal(lastOptions.configuration?.features?.mcp, true, 'registered tools advertis
 equal(lastOptions.configuration?.features?.aec, true, 'AEC is explicitly advertised')
 equal(lastOptions.configuration?.features?.glyph_push, undefined, 'glyph push remains unadvertised')
 equal(lastOptions.functions?.length, 1, 'tool schemas should reach the worker')
+
+const beforeRejected = ChatAudioIOAny.instances?.length
+for (const turnControl of ['fullDuplex', 'invalid']) {
+  let rejected = false
+  try {
+    new ChatService({ connection, turnControl: turnControl as 'fullDuplex', chatAudioIOCtor: ChatAudioIO as any })
+  } catch {
+    rejected = true
+  }
+  equal(rejected, true, 'unsupported modes must fail before creating audio resources')
+}
+equal(ChatAudioIOAny.instances?.length, beforeRejected, 'rejected modes allocate no AudioIO')
 
 service.start()
 equal(states[0], ChatState.CONNECTING, 'state should map to CONNECTING')

--- a/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
+++ b/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
@@ -109,7 +109,11 @@ const beforeRejected = ChatAudioIOAny.instances?.length
 for (const turnControl of ['fullDuplex', 'invalid']) {
   let rejected = false
   try {
-    new ChatService({ connection, turnControl: turnControl as 'fullDuplex', chatAudioIOCtor: ChatAudioIO as any })
+    new ChatService({
+      connection,
+      turnControl: turnControl as 'fullDuplex',
+      chatAudioIOCtor: ChatAudioIO as unknown as new (chatOptions: Record<string, unknown>) => ChatAudioIOBase,
+    })
   } catch {
     rejected = true
   }

--- a/firmware/host/modules/conversation/__tests__/server-realtime-model/xiaozhi-model.test.ts
+++ b/firmware/host/modules/conversation/__tests__/server-realtime-model/xiaozhi-model.test.ts
@@ -356,3 +356,49 @@ const secondRepeatedEncoder = OpusEncoder.instances[OpusEncoder.instances.length
 repeatedHello.close()
 equal(secondRepeatedDecoder.closed, true, 'close should release the active decoder')
 equal(secondRepeatedEncoder.closed, true, 'close should release the active encoder')
+
+resetTransport()
+const encoderCount = OpusEncoder.instances.length
+const downlink = new XiaozhiModel({ inputSampleRate: 16000, outputSampleRate: 24000 })
+downlink.configure({
+  turnControl: 'downlink',
+  configuration: {
+    protocol: 'xiaozhi-v1',
+    endpoint: 'wss://relay.example.test/ws',
+    identity: { deviceId: 'core-s3', clientId: 'downlink' },
+  },
+})
+downlink.connect({ ...connection, inputBuffer: undefined })
+downlink.onOpen()
+downlink.onJSON(repeatedHelloEvent)
+equal(OpusEncoder.instances.length, encoderCount, 'downlink never constructs an encoder')
+equal(downlink.encoderTimer, undefined, 'downlink never starts the encoder timer')
+equal(downlink.uploading, false, 'downlink accepts server audio immediately')
+downlink.startListening()
+downlink.stopListening()
+downlink.detectWakeWord({ text: 'ignored' })
+downlink.onJSON({ type: 'tts', state: 'start' })
+downlink.read(Uint8Array.of(0xf8, 0xff, 0xfe).buffer, { binary: true })
+downlink.onJSON({ type: 'tts', state: 'stop' })
+downlink.listened()
+equal(
+  sentJSON.some((event) => event.type === 'listen'),
+  false,
+  'downlink never sends listen commands',
+)
+equal(sentBinary.length, 0, 'downlink never uploads audio')
+equal(downlink.parser.copied.length, 2, 'downlink uses the common decoder and PCM parser')
+const outputStart = postedMessages.find((event) => event.id === 'listen')
+const outputEnd = postedMessages.find((event) => event.id === 'speak')
+equal(outputStart?.turnId, outputEnd?.turnId, 'local playback boundaries keep their identity')
+equal(outputEnd?.endByte, 1920, 'stop marks decoded audio plus the final silence frame')
+downlink.close()
+
+for (const turnControl of ['fullDuplex', 'invalid']) {
+  resetTransport()
+  const peer = new XiaozhiModel({})
+  peer.configure({ turnControl })
+  peer.connect(connection)
+  equal(peer.connectCount, 0, 'unsupported worker modes cannot open a socket')
+  equal(postedMessages[0]?.id, 'failed', 'unsupported worker modes fail closed')
+}

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/audio-in.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/audio-in.js
@@ -1,0 +1,11 @@
+export default class AudioIn {
+  static instances = []
+  constructor(options) {
+    this.options = options
+    AudioIn.instances.push(this)
+  }
+  start() {}
+  close() {
+    this.closed = true
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/audio-out.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/audio-out.js
@@ -1,0 +1,18 @@
+export default class AudioOut {
+  static instances = []
+  constructor(options) {
+    this.options = options
+    this.writes = []
+    AudioOut.instances.push(this)
+  }
+  start() {}
+  close() {
+    this.closed = true
+  }
+  write(samples) {
+    this.writes.push(new Uint8Array(samples).slice())
+  }
+  tick(size = 960) {
+    if (!this.closed) this.options.onWritable(size)
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/manifest.test.json
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/manifest.test.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "../../../testing/manifest.json"
+  ],
+  "modules": {
+    "main": "./xiaozhi-audioio.test",
+    "ChatAudioIO": "$(MODDABLE)/modules/network/services/chatAudioIO/ChatAudioIO",
+    "StackChanChatAudioIO": "../../chat-audioio/worker-stack",
+    "stackchanPcmRingWriter": "./pcm-ring-writer",
+    "stackchanXiaozhiAudioIOBase": "../../chat-audioio/xiaozhi-audioio-base",
+    "embedded:io/audio/in": "./audio-in",
+    "embedded:io/audio/out": "./audio-out",
+    "worker": "./worker"
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/manifest.test.json
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/manifest.test.json
@@ -1,9 +1,7 @@
 {
-  "include": [
-    "$(MODDABLE)/examples/manifest_base.json",
-    "../../../testing/manifest.json"
-  ],
+  "include": ["../../manifest.json", "../../../testing/manifest.json"],
   "modules": {
+    "~": ["../../StackChanChatAudioIO", "../../chat-audioio/pcm-ring-writer"],
     "main": "./xiaozhi-audioio.test",
     "ChatAudioIO": "$(MODDABLE)/modules/network/services/chatAudioIO/ChatAudioIO",
     "StackChanChatAudioIO": "../../chat-audioio/worker-stack",

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/pcm-ring-writer.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/pcm-ring-writer.js
@@ -1,0 +1,3 @@
+export function writePcmRing() {
+  throw new Error('downlink must not write microphone PCM')
+}

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/worker.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/worker.js
@@ -1,0 +1,13 @@
+export default class Worker {
+  static instances = []
+  constructor() {
+    this.messages = []
+    Worker.instances.push(this)
+  }
+  postMessage(message) {
+    this.messages.push(message)
+  }
+  terminate() {
+    this.closed = true
+  }
+}

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/xiaozhi-audioio.test.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/xiaozhi-audioio.test.js
@@ -1,10 +1,10 @@
-import AudioIO from 'stackchanXiaozhiAudioIOBase'
 import StackAudioIO from 'StackChanChatAudioIO'
+import AudioIO from 'stackchanXiaozhiAudioIOBase'
 import AudioIn from 'embedded:io/audio/in'
 import AudioOut from 'embedded:io/audio/out'
-import Worker from 'worker'
 import { equal } from 'testing/assert'
 import Timer from 'timer'
+import Worker from 'worker'
 
 async function run() {
   for (const turnControl of ['fullDuplex', 'invalid']) {

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/xiaozhi-audioio.test.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/xiaozhi-audioio.test.js
@@ -21,12 +21,14 @@ async function run() {
 
   const transitions = []
   const levels = []
+  const calls = []
   const audio = new StackAudioIO({
     specifier: 'xiaozhiV1',
     turnControl: 'downlink',
     onOutputTurnStarted: (turn) => transitions.push(`start:${turn.id}`),
     onOutputTurnEnded: (turn) => transitions.push(`end:${turn.id}`),
     onOutputLevelChanged: (level) => levels.push(level),
+    onFunctionCall: (call) => calls.push(call),
   })
   equal(audio.inputBuffer, undefined, 'downlink has no input PCM buffer')
   equal(audio.worker !== undefined, true, 'production factory installs a Worker')
@@ -41,6 +43,7 @@ async function run() {
   audio.receiveAudio({ offset: 0, size: 960 })
   audio.speak({ turnId: 1, endByte: 960 })
   audio.listen({ turnId: 2 })
+  audio.receiveFunctionCall({ turnId: 2, call: 'second-turn-tool', name: 'pose', parameters: {} })
   audio.receiveAudio({ offset: 960, size: 960 })
   audio.speak({ turnId: 2, endByte: 1920 })
   equal(levels.length, 0, 'receiving frames does not publish future mouth levels')
@@ -48,8 +51,10 @@ async function run() {
   output.tick(1920)
   equal(audio.playedBytes, 960, 'one write cannot cross a pending turn boundary')
   equal(transitions.join(','), 'start:1', 'first turn has not drained at submission')
+  equal(calls.length, 0, 'future turn tools do not run over the current turn')
   output.tick()
   equal(transitions.join(','), 'start:1,end:1,start:2', 'queued turns start after the preceding drain')
+  equal(calls.join(','), 'second-turn-tool', 'tools are dispatched after their own turn starts')
   output.tick()
   output.tick()
   equal(transitions.join(','), 'start:1,end:1,start:2,end:2', 'turn ends preserve FIFO identity')

--- a/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/xiaozhi-audioio.test.js
+++ b/firmware/host/modules/conversation/__tests__/xiaozhi-audioio/xiaozhi-audioio.test.js
@@ -1,0 +1,91 @@
+import AudioIO from 'stackchanXiaozhiAudioIOBase'
+import StackAudioIO from 'StackChanChatAudioIO'
+import AudioIn from 'embedded:io/audio/in'
+import AudioOut from 'embedded:io/audio/out'
+import Worker from 'worker'
+import { equal } from 'testing/assert'
+import Timer from 'timer'
+
+async function run() {
+  for (const turnControl of ['fullDuplex', 'invalid']) {
+    let rejected = false
+    try {
+      new AudioIO({ turnControl })
+    } catch {
+      rejected = true
+    }
+    equal(rejected, true, 'unsupported mode rejected')
+  }
+  equal(Worker.instances.length, 0, 'rejection creates no worker')
+  equal(AudioIn.instances.length, 0, 'rejection creates no input')
+
+  const transitions = []
+  const levels = []
+  const audio = new StackAudioIO({
+    specifier: 'xiaozhiV1',
+    turnControl: 'downlink',
+    onOutputTurnStarted: (turn) => transitions.push(`start:${turn.id}`),
+    onOutputTurnEnded: (turn) => transitions.push(`end:${turn.id}`),
+    onOutputLevelChanged: (level) => levels.push(level),
+  })
+  equal(audio.inputBuffer, undefined, 'downlink has no input PCM buffer')
+  equal(audio.worker !== undefined, true, 'production factory installs a Worker')
+  equal(Worker.instances[0].messages[0].pcmRing, undefined, 'production worker has no capture ring')
+  equal(Worker.instances[0].messages[0].turnControl, 'downlink', 'worker receives turnControl')
+  equal(AudioIn.instances.length, 0, 'downlink never opens AudioIn')
+  audio.connect()
+  audio.connected()
+  equal(audio.state, AudioIO.CONNECTED, 'downlink waits without starting a microphone turn')
+  new Int16Array(audio.outputBuffer, 0, 960).fill(1000)
+  audio.listen({ turnId: 1 })
+  audio.receiveAudio({ offset: 0, size: 960 })
+  audio.speak({ turnId: 1, endByte: 960 })
+  audio.listen({ turnId: 2 })
+  audio.receiveAudio({ offset: 960, size: 960 })
+  audio.speak({ turnId: 2, endByte: 1920 })
+  equal(levels.length, 0, 'receiving frames does not publish future mouth levels')
+  const output = AudioOut.instances[0]
+  output.tick(1920)
+  equal(audio.playedBytes, 960, 'one write cannot cross a pending turn boundary')
+  equal(transitions.join(','), 'start:1', 'first turn has not drained at submission')
+  output.tick()
+  equal(transitions.join(','), 'start:1,end:1,start:2', 'queued turns start after the preceding drain')
+  output.tick()
+  output.tick()
+  equal(transitions.join(','), 'start:1,end:1,start:2,end:2', 'turn ends preserve FIFO identity')
+  equal(audio.state, AudioIO.CONNECTED, 'downlink stays connected after playback')
+  equal(AudioIn.instances.length, 0, 'drain never creates an input')
+  audio.close()
+
+  let release
+  let staleContext
+  const delayed = new AudioIO({
+    turnControl: 'downlink',
+    onOutputTurnStarted: (turn) => {
+      staleContext = turn
+      return new Promise((resolve) => {
+        release = resolve
+      })
+    },
+  })
+  delayed.connect()
+  delayed.connected()
+  delayed.listen({ turnId: 1 })
+  const outputCount = AudioOut.instances.length
+  delayed.close()
+  release()
+  await Promise.resolve()
+  equal(staleContext.isCurrent(), false, 'close invalidates an unfinished start hook')
+  equal(AudioOut.instances.length, outputCount, 'late start completion cannot reopen AudioOut')
+  equal(Atomics.load(delayed.barrier, 0), -1, 'close wakes the producer with a cancellation sentinel')
+
+  const legacy = new AudioIO({})
+  equal(AudioIn.instances.length, 1, 'halfDuplex remains the default')
+  legacy.close()
+  trace('ok\n')
+  Timer.set(() => {}, 1000)
+}
+run().catch((error) => {
+  trace(`FAIL: ${error}\n`)
+  throw error
+})

--- a/firmware/host/modules/conversation/chat-audioio/server-chat-websocket-worker.js
+++ b/firmware/host/modules/conversation/chat-audioio/server-chat-websocket-worker.js
@@ -12,6 +12,18 @@ import TextEncoder from 'text/encoder'
 const text = Object.freeze({ binary: false })
 const MAX_QUEUED_BYTES = 64 * 1024
 
+class CancelablePCMParser extends JSONBase64Parser {
+  wait(head, size, space) {
+    let tail = Atomics.load(this.barrier, 0)
+    while (((tail - (head + 1)) & (size - 1)) < space) {
+      if (tail < 0) throw new Error('audio output closed')
+      Atomics.wait(this.barrier, 0, tail)
+      tail = Atomics.load(this.barrier, 0)
+    }
+    if (tail < 0) throw new Error('audio output closed')
+  }
+}
+
 export default class ServerChatWebSocketWorker extends ChatWorker {
   #buffers = []
   #queuedBytes = 0
@@ -49,7 +61,7 @@ export default class ServerChatWebSocketWorker extends ChatWorker {
 
   connect(message) {
     super.connect(message)
-    this.parser = new JSONBase64Parser(this, this.outputBuffer, 2, this.outputMinimum)
+    this.parser = new CancelablePCMParser(this, this.outputBuffer, 2, this.outputMinimum)
     this.parser.barrier = message.barrier
     const network = this.secure ? device.network.wss : device.network.ws
     const WebSocketClient = network.io ?? device.network.ws.io

--- a/firmware/host/modules/conversation/chat-audioio/worker-stack.js
+++ b/firmware/host/modules/conversation/chat-audioio/worker-stack.js
@@ -1,170 +1,182 @@
 import ChatAudioIOBase from 'ChatAudioIO'
+import XiaozhiAudioIOBase from 'stackchanXiaozhiAudioIOBase'
 import { writePcmRing } from 'stackchanPcmRingWriter'
 import Worker from 'worker'
 
 const CONNECTION_ENVELOPE = '__stackchanConnectionConfiguration'
 
-export default class ChatAudioIO extends ChatAudioIOBase {
-  constructor(options = {}) {
-    const providerID =
-      options.configuration === undefined
-        ? options.providerID
-        : {
-            [CONNECTION_ENVELOPE]: true,
-            configuration: options.configuration,
-          }
-    super({ ...options, providerID })
-    const callback = () => {}
-    this.onEmotionChanged = options.onEmotionChanged ?? callback
-    this.onAlert = options.onAlert ?? callback
-    this.onSystemCommand = options.onSystemCommand ?? callback
-    this.onCustomEvent = options.onCustomEvent ?? callback
-    this.onUnknownEvent = options.onUnknownEvent ?? callback
-    this.onProtocolWarning = options.onProtocolWarning ?? callback
-    this.onMcpNotification = options.onMcpNotification ?? callback
-    this.onMcpResponse = options.onMcpResponse ?? callback
-    this.onGlyphPush = options.onGlyphPush ?? callback
-  }
-
-  ensureInput() {
-    if (!this.immediateInputReady) {
-      super.ensureInput()
-      return
-    }
-    const notify = !this.ready && this.state !== ChatAudioIO.DISCONNECTED
-    super.ensureInput()
-    if (!this.input || this.ready) return
-    this.ready = true
-    if (notify) this.onStateChanged(this.state)
-  }
-
-  createWorker(specifier, instructions, functions, voiceID, providerID, modelID, apiKey) {
-    let configuration
-    if (providerID && typeof providerID === 'object' && providerID[CONNECTION_ENVELOPE] === true) {
-      configuration = providerID.configuration
-      providerID = undefined
+const withStackWorker = (Base) =>
+  class extends Base {
+    constructor(options = {}) {
+      const providerID =
+        options.configuration === undefined
+          ? options.providerID
+          : {
+              [CONNECTION_ENVELOPE]: true,
+              configuration: options.configuration,
+            }
+      super({ ...options, providerID })
+      const callback = () => {}
+      this.onEmotionChanged = options.onEmotionChanged ?? callback
+      this.onAlert = options.onAlert ?? callback
+      this.onSystemCommand = options.onSystemCommand ?? callback
+      this.onCustomEvent = options.onCustomEvent ?? callback
+      this.onUnknownEvent = options.onUnknownEvent ?? callback
+      this.onProtocolWarning = options.onProtocolWarning ?? callback
+      this.onMcpNotification = options.onMcpNotification ?? callback
+      this.onMcpResponse = options.onMcpResponse ?? callback
+      this.onGlyphPush = options.onGlyphPush ?? callback
     }
 
-    const usesNativePcmRing = specifier === 'xiaozhiV1'
-    this.immediateInputReady = usesNativePcmRing
-    if (usesNativePcmRing) this.inputSampleRate = 16000
-
-    const worker = new Worker(specifier, {
-      static: 512 * 1024,
-      chunk: {
-        initial: 64 * 1024,
-        incremental: 8 * 1024,
-      },
-      heap: {
-        initial: 1024,
-        incremental: 256,
-      },
-      stack: 1024,
-      nativeStack: 40 * 1024,
-      priority: 4,
-    })
-    // Shared PCM ring (~1.92 s of 16 kHz mono). Main writes via native
-    // downmix; the Opus task reads it. Do not copy samples in JS or wait
-    // for a Worker ACK — both previously dropped mic frames.
-    const PCM_FRAME_BYTES = 1920
-    const PCM_RING_BYTES = PCM_FRAME_BYTES * 32 + 2
-    const PCM_RING_STATE_BYTES = 4 * 4
-    const pcmRing = usesNativePcmRing ? new SharedArrayBuffer(PCM_RING_BYTES) : undefined
-    const pcmRingState = usesNativePcmRing ? new SharedArrayBuffer(PCM_RING_STATE_BYTES) : undefined
-
-    this.worker = {
-      terminate: () => worker.terminate(),
-      postMessage: (message) => {
-        if (message.id !== 'sendAudio' || !usesNativePcmRing) {
-          worker.postMessage(message)
-          return
-        }
-        if (!this.inputBuffer || !pcmRing || !pcmRingState) return
-        try {
-          writePcmRing(pcmRing, pcmRingState, this.inputBuffer, message.offset, message.size, message.channels ?? 2)
-        } catch (error) {
-          this.failed({ string: `PCM ring write failed: ${String(error?.message ?? error)}` })
-        }
-      },
-    }
-    worker.onmessage = (message) => {
-      if (message.id === 'audioConsumed') return
-      const handler = this[message.id]
-      if (typeof handler === 'function') {
-        handler.call(this, message)
+    ensureInput() {
+      if (!this.immediateInputReady) {
+        super.ensureInput()
         return
       }
-      trace(`[chat] ignored worker message: ${String(message.id)}\n`)
+      const notify = !this.ready && this.state !== ChatAudioIO.DISCONNECTED
+      super.ensureInput()
+      if (!this.input || this.ready) return
+      this.ready = true
+      if (notify) this.onStateChanged(this.state)
     }
-    this.worker.postMessage({
-      id: 'configure',
-      configuration,
-      pcmRing,
-      pcmRingState,
-      // Legacy fields remain available to existing ChatAudioIO workers.
-      instructions,
-      functions,
-      voiceID,
-      providerID,
-      modelID,
-      apiKey,
-    })
-    this.ensureInput()
+
+    createWorker(specifier, instructions, functions, voiceID, providerID, modelID, apiKey) {
+      let configuration
+      if (providerID && typeof providerID === 'object' && providerID[CONNECTION_ENVELOPE] === true) {
+        configuration = providerID.configuration
+        providerID = undefined
+      }
+
+      const usesNativePcmRing = specifier === 'xiaozhiV1' && this.turnControl !== 'downlink'
+      this.immediateInputReady = usesNativePcmRing
+      if (usesNativePcmRing) this.inputSampleRate = 16000
+
+      const worker = new Worker(specifier, {
+        static: 512 * 1024,
+        chunk: {
+          initial: 64 * 1024,
+          incremental: 8 * 1024,
+        },
+        heap: {
+          initial: 1024,
+          incremental: 256,
+        },
+        stack: 1024,
+        nativeStack: 40 * 1024,
+        priority: 4,
+      })
+      // Shared PCM ring (~1.92 s of 16 kHz mono). Main writes via native
+      // downmix; the Opus task reads it. Do not copy samples in JS or wait
+      // for a Worker ACK — both previously dropped mic frames.
+      const PCM_FRAME_BYTES = 1920
+      const PCM_RING_BYTES = PCM_FRAME_BYTES * 32 + 2
+      const PCM_RING_STATE_BYTES = 4 * 4
+      const pcmRing = usesNativePcmRing ? new SharedArrayBuffer(PCM_RING_BYTES) : undefined
+      const pcmRingState = usesNativePcmRing ? new SharedArrayBuffer(PCM_RING_STATE_BYTES) : undefined
+
+      this.worker = {
+        terminate: () => worker.terminate(),
+        postMessage: (message) => {
+          if (message.id !== 'sendAudio' || !usesNativePcmRing) {
+            worker.postMessage(message)
+            return
+          }
+          if (!this.inputBuffer || !pcmRing || !pcmRingState) return
+          try {
+            writePcmRing(pcmRing, pcmRingState, this.inputBuffer, message.offset, message.size, message.channels ?? 2)
+          } catch (error) {
+            this.failed({ string: `PCM ring write failed: ${String(error?.message ?? error)}` })
+          }
+        },
+      }
+      worker.onmessage = (message) => {
+        if (message.id === 'audioConsumed') return
+        const handler = this[message.id]
+        if (typeof handler === 'function') {
+          handler.call(this, message)
+          return
+        }
+        trace(`[chat] ignored worker message: ${String(message.id)}\n`)
+      }
+      this.worker.postMessage({
+        id: 'configure',
+        configuration,
+        turnControl: this.turnControl ?? 'halfDuplex',
+        pcmRing,
+        pcmRingState,
+        // Legacy fields remain available to existing ChatAudioIO workers.
+        instructions,
+        functions,
+        voiceID,
+        providerID,
+        modelID,
+        apiKey,
+      })
+      this.ensureInput()
+    }
+
+    startListening(mode = 'auto') {
+      this.worker?.postMessage({ id: 'startListening', mode })
+    }
+
+    stopListening() {
+      this.worker?.postMessage({ id: 'stopListening' })
+    }
+
+    notifyWakeWordDetected(text) {
+      this.worker?.postMessage({ id: 'detectWakeWord', text })
+    }
+
+    abort(reason) {
+      this.worker?.postMessage({ id: 'abort', reason })
+    }
+
+    sendMcpMessage(payload) {
+      this.worker?.postMessage({ id: 'sendMcpMessage', payload })
+    }
+
+    receiveEmotion(message) {
+      this.onEmotionChanged(message.emotion ?? '', message.text)
+    }
+
+    receiveAlert(message) {
+      this.onAlert({ status: message.status, message: message.message ?? '', emotion: message.emotion })
+    }
+
+    receiveSystemCommand(message) {
+      this.onSystemCommand({ command: message.command ?? '', event: message.event ?? {} })
+    }
+
+    receiveCustomEvent(message) {
+      this.onCustomEvent({ payload: message.payload, event: message.event ?? {} })
+    }
+
+    receiveUnknownEvent(message) {
+      this.onUnknownEvent(message.event ?? {})
+    }
+
+    protocolWarning(message) {
+      this.onProtocolWarning(message.string ?? 'protocol warning', message.event)
+    }
+
+    receiveMcpNotification(message) {
+      this.onMcpNotification(message.payload ?? {})
+    }
+
+    receiveMcpResponse(message) {
+      this.onMcpResponse(message.payload ?? {})
+    }
+
+    receiveGlyphPush(message) {
+      this.onGlyphPush({ source: message.source, text: message.text, payload: message.payload ?? {} })
+    }
   }
 
-  startListening(mode = 'auto') {
-    this.worker?.postMessage({ id: 'startListening', mode })
-  }
+const LegacyAudioIO = withStackWorker(ChatAudioIOBase)
+const XiaozhiAudioIO = withStackWorker(XiaozhiAudioIOBase)
 
-  stopListening() {
-    this.worker?.postMessage({ id: 'stopListening' })
-  }
-
-  notifyWakeWordDetected(text) {
-    this.worker?.postMessage({ id: 'detectWakeWord', text })
-  }
-
-  abort(reason) {
-    this.worker?.postMessage({ id: 'abort', reason })
-  }
-
-  sendMcpMessage(payload) {
-    this.worker?.postMessage({ id: 'sendMcpMessage', payload })
-  }
-
-  receiveEmotion(message) {
-    this.onEmotionChanged(message.emotion ?? '', message.text)
-  }
-
-  receiveAlert(message) {
-    this.onAlert({ status: message.status, message: message.message ?? '', emotion: message.emotion })
-  }
-
-  receiveSystemCommand(message) {
-    this.onSystemCommand({ command: message.command ?? '', event: message.event ?? {} })
-  }
-
-  receiveCustomEvent(message) {
-    this.onCustomEvent({ payload: message.payload, event: message.event ?? {} })
-  }
-
-  receiveUnknownEvent(message) {
-    this.onUnknownEvent(message.event ?? {})
-  }
-
-  protocolWarning(message) {
-    this.onProtocolWarning(message.string ?? 'protocol warning', message.event)
-  }
-
-  receiveMcpNotification(message) {
-    this.onMcpNotification(message.payload ?? {})
-  }
-
-  receiveMcpResponse(message) {
-    this.onMcpResponse(message.payload ?? {})
-  }
-
-  receiveGlyphPush(message) {
-    this.onGlyphPush({ source: message.source, text: message.text, payload: message.payload ?? {} })
-  }
+export default function ChatAudioIO(options = {}) {
+  // Constructor-compatible factory: don't run the SDK constructor for XiaoZhi.
+  return new (options.specifier === 'xiaozhiV1' ? XiaozhiAudioIO : LegacyAudioIO)(options)
 }
+Object.setPrototypeOf(ChatAudioIO, ChatAudioIOBase)

--- a/firmware/host/modules/conversation/chat-audioio/worker-stack.js
+++ b/firmware/host/modules/conversation/chat-audioio/worker-stack.js
@@ -1,6 +1,6 @@
 import ChatAudioIOBase from 'ChatAudioIO'
-import XiaozhiAudioIOBase from 'stackchanXiaozhiAudioIOBase'
 import { writePcmRing } from 'stackchanPcmRingWriter'
+import XiaozhiAudioIOBase from 'stackchanXiaozhiAudioIOBase'
 import Worker from 'worker'
 
 const CONNECTION_ENVELOPE = '__stackchanConnectionConfiguration'

--- a/firmware/host/modules/conversation/chat-audioio/xiaozhi-audioio-base.js
+++ b/firmware/host/modules/conversation/chat-audioio/xiaozhi-audioio-base.js
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2024-2026 Moddable Tech, Inc.
+ *
+ *   This file is part of the Moddable SDK Runtime.
+ *
+ *   The Moddable SDK Runtime is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   The Moddable SDK Runtime is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with the Moddable SDK Runtime.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import AudioIn from 'embedded:io/audio/in'
+import AudioOut from 'embedded:io/audio/out'
+import Worker from 'worker'
+
+// Host-owned XiaoZhi adapter, derived from Moddable SDK 9.5 ChatAudioIO.
+// Keep the upstream LGPL notice above. Other providers still use the SDK class.
+
+function computeLevel(buffer) {
+  return native('xs_computeLevel').call(this, buffer)
+}
+
+class ChatAudioIO {
+  static FAILED = -1
+  static DISCONNECTED = 0
+  static DISCONNECTING = 1
+  static CONNECTING = 2
+  static CONNECTED = 3
+  static SPEAKING = 4 // user is speaking (sending audio to cloud)
+  static LISTENING = 5 // user is listening (receiving audio from cloud)
+  static WAITING = 6
+  static states = ['DISCONNECTED', 'DISCONNECTING', 'CONNECTING', 'CONNECTED', 'SPEAKING', 'LISTENING', 'WAITING']
+  static {
+    ChatAudioIO.states[-1] = 'FAILED'
+    Object.freeze(ChatAudioIO.states)
+  }
+
+  constructor(options) {
+    this.turnControl = options.turnControl ?? 'halfDuplex'
+    if (!['halfDuplex', 'downlink'].includes(this.turnControl))
+      throw new Error(this.turnControl === 'fullDuplex' ? 'fullDuplex is not implemented' : 'Invalid turnControl')
+    this.turns = []
+    this.playedBytes = 0
+    this.generation = 0
+    this.onOutputTurnStarted = options.onOutputTurnStarted ?? (() => {})
+    this.onOutputTurnEnded = options.onOutputTurnEnded ?? (() => {})
+    this.error = ''
+    this.state = ChatAudioIO.DISCONNECTED
+
+    this.input = null
+    this.inputBufferOffset = 0
+    this.inputBufferSize = 512 * 1024
+    this.inputBuffer = this.turnControl === 'downlink' ? undefined : new SharedArrayBuffer(this.inputBufferSize)
+    this.inputSampleRate = 24000
+    this.ready = false
+
+    this.output = null
+    this.outputBufferSize = 512 * 1024
+    this.outputBuffer = new SharedArrayBuffer(this.outputBufferSize)
+    this.outputSampleRate = 24000
+    this.outputBufferHead = 0
+    this.outputBufferTail = 0
+    this.barrier = new Int32Array(new SharedArrayBuffer(4))
+
+    this.level = 0
+    this.microphone = 1
+    this.volume = 1
+
+    const callback = () => {}
+    this.onFunctionCall = options.onFunctionCall ?? callback
+    this.onInputLevelChanged = options.onInputLevelChanged ?? callback
+    this.onInputTranscript = options.onInputTranscript ?? callback
+    this.onOutputLevelChanged = options.onOutputLevelChanged
+    this.onOutputTranscript = options.onOutputTranscript ?? callback
+    this.onStateChanged = options.onStateChanged ?? callback
+
+    this.createWorker(
+      options.specifier,
+      options.instructions,
+      options.functions,
+      options.voiceID,
+      options.providerID,
+      options.modelID,
+      options.apiKey,
+    )
+  }
+  close() {
+    this.clearOutput()
+    this.worker?.terminate()
+    this.worker = null
+    this.output?.close()
+    this.output = null
+    this.input?.close()
+    this.input = null
+  }
+  changeMicrophone(microphone) {
+    this.microphone = microphone
+  }
+  changeVolume(volume) {
+    this.volume = volume
+    if (this.output) this.output.volume = volume
+  }
+  createWorker(specifier, instructions, functions, voiceID, providerID, modelID, apiKey) {
+    this.worker = new Worker(specifier, {
+      static: 512 * 1024,
+      chunk: {
+        initial: 64 * 1024,
+        incremental: 8 * 1024,
+      },
+      heap: {
+        initial: 1024,
+        incremental: 256,
+      },
+      stack: 1024,
+      nativeStack: 12 * 1024,
+    })
+    this.worker.onmessage = (message) => {
+      this[message.id](message)
+    }
+    this.worker.postMessage({
+      id: 'configure',
+      instructions,
+      functions,
+      voiceID,
+      providerID,
+      modelID,
+      apiKey,
+    })
+    this.ensureInput()
+  }
+  configureAudio(message) {
+    const inputSampleRate = message.inputSampleRate ?? 24000
+    if (this.inputSampleRate !== inputSampleRate) {
+      this.inputSampleRate = inputSampleRate
+      if (this.input) {
+        this.input.close()
+        this.input = null
+        this.ensureInput()
+      }
+    }
+    const outputSampleRate = message.outputSampleRate ?? 24000
+    if (this.outputSampleRate !== outputSampleRate) {
+      this.outputSampleRate = outputSampleRate
+      if (this.output) {
+        this.output.close()
+        this.output = null
+        this.ensureOutput()
+      }
+    }
+  }
+  connect() {
+    this.state = ChatAudioIO.CONNECTING
+    this.inputBufferOffset = 0
+    Atomics.store(this.barrier, 0, 0)
+    this.worker.postMessage({
+      id: 'connect',
+      inputBuffer: this.inputBuffer,
+      outputBuffer: this.outputBuffer,
+      barrier: this.barrier,
+    })
+    this.onStateChanged(this.state)
+  }
+  connected() {
+    this.state = ChatAudioIO.CONNECTED
+    this.onStateChanged(this.state)
+    if (this.turnControl === 'downlink') return
+    this.state = ChatAudioIO.SPEAKING
+    if (this.ready) this.onStateChanged(this.state)
+  }
+  disconnect() {
+    this.clearOutput()
+    this.state = ChatAudioIO.DISCONNECTING
+    this.worker.postMessage({ id: 'disconnect' })
+    this.onStateChanged(this.state)
+  }
+  disconnected() {
+    this.clearOutput()
+    this.error = ''
+    this.state = ChatAudioIO.DISCONNECTED
+    this.ensureInput()
+    this.onStateChanged(this.state)
+  }
+  failed(message) {
+    this.clearOutput()
+    this.error = message.string
+    this.state = ChatAudioIO.FAILED
+    this.ensureInput()
+    this.onStateChanged(this.state)
+  }
+  listen(message = {}) {
+    if (this.turns.length >= 64) return this.failed({ string: 'Too many queued XiaoZhi turns' })
+    this.turns.push({ id: message.turnId, generation: this.generation, calls: [] })
+    if (this.turns.length === 1) this.beginOutputTurn()
+  }
+  receiveAudio(message) {
+    this.outputBufferHead = message.offset + message.size
+  }
+  receiveFunctionCall(message) {
+    const turn = this.turns.find((turn) => turn.id === message.turnId)
+    if (turn && !turn.ready) {
+      if (turn.calls.length >= 32) return this.failed({ string: 'Too many queued XiaoZhi tool calls' })
+      turn.calls.push(message)
+      return
+    }
+    this.onFunctionCall(message.call, message.name, message.parameters)
+  }
+  receiveInputText(message) {
+    this.onInputTranscript(message.text, message.more)
+  }
+  receiveOutputText(message) {
+    this.onOutputTranscript(message.text, message.more)
+  }
+  sendFunctionResult(call, name, result) {
+    this.worker.postMessage({ id: 'sendFunctionResult', call, name, result })
+  }
+  sendText(text) {
+    if (this.state < ChatAudioIO.CONNECTED) throw new Error('not connected')
+    if (this.state > ChatAudioIO.SPEAKING) throw new Error('listening')
+    this.worker.postMessage({ id: 'sendText', text })
+  }
+  speak(message = {}) {
+    const turn = this.turns.find((turn) => turn.id === message.turnId)
+    if (turn) turn.end = message.endByte
+  }
+  clearOutput() {
+    this.generation++
+    this.turns.length = 0
+    this.playedBytes = 0
+    this.outputBufferHead = this.outputBufferTail = 0
+    this.output?.close()
+    this.output = null
+    // Wake a decoder waiting for ring space before terminating its Worker.
+    Atomics.store(this.barrier, 0, -1)
+    Atomics.notify(this.barrier, 0)
+  }
+  beginOutputTurn() {
+    const turn = this.turns[0]
+    if (!turn || turn.begun) return
+    turn.begun = true
+    turn.context = { id: turn.id, isCurrent: () => this.turns[0] === turn && turn.generation === this.generation }
+    this.settleTurnHook(
+      turn,
+      () => this.onOutputTurnStarted(turn.context),
+      () => {
+        turn.ready = true
+        for (const call of turn.calls) this.receiveFunctionCall(call)
+        turn.calls.length = 0
+        this.state = ChatAudioIO.LISTENING
+        this.ensureOutput()
+        this.onStateChanged(this.state)
+      },
+    )
+  }
+  settleTurnHook(turn, operation, continuation) {
+    const resume = () => {
+      if (!turn.context.isCurrent()) return
+      try {
+        continuation()
+      } catch (error) {
+        fail(error)
+      }
+    }
+    const fail = (error) => {
+      if (turn.context.isCurrent()) this.failed({ string: String(error?.message ?? error) })
+    }
+    try {
+      const result = operation()
+      if (result && typeof result.then === 'function') result.then(resume, fail)
+      else resume()
+    } catch (error) {
+      fail(error)
+    }
+  }
+  finishOutputTurn(turn) {
+    if (turn.ending) return
+    turn.ending = true
+    this.settleTurnHook(
+      turn,
+      () => this.onOutputTurnEnded(turn.context),
+      () => {
+        this.turns.shift()
+        if (this.turns.length) this.beginOutputTurn()
+        else {
+          this.output?.close()
+          this.output = null
+          this.state = this.turnControl === 'downlink' ? ChatAudioIO.CONNECTED : ChatAudioIO.SPEAKING
+          this.worker?.postMessage({ id: 'listened' })
+          this.ensureInput()
+          this.onStateChanged(this.state)
+        }
+      },
+    )
+  }
+
+  ensureInput() {
+    if (this.turnControl === 'downlink') return
+    if (this.input) return
+    this.output?.close()
+    this.output = null
+    const when = Date.now() + 500
+    this.input = new AudioIn({
+      sampleRate: this.inputSampleRate,
+      onReadable: (size) => {
+        if (!this.ready) {
+          if (Date.now() >= when) {
+            this.ready = true
+            if (this.state !== ChatAudioIO.DISCONNECTED) this.onStateChanged(this.state)
+          } else return
+        }
+        if (!this.microphone) return
+        let delta = this.inputBufferSize - this.inputBufferOffset
+        if (delta < size) {
+          this.inputBufferOffset = 0
+          delta = this.inputBufferSize
+        }
+        const samples = new Uint8Array(this.inputBuffer, this.inputBufferOffset, size)
+        this.input.read(samples)
+        const level = computeLevel(samples)
+        if (this.level !== level) {
+          this.level = level
+          this.onInputLevelChanged(level)
+        }
+        if (this.state === ChatAudioIO.SPEAKING) {
+          this.worker.postMessage({ id: 'sendAudio', offset: this.inputBufferOffset, size })
+        }
+        this.inputBufferOffset += size
+      },
+    })
+    this.input.start()
+  }
+  ensureOutput() {
+    if (this.output) return
+    this.input?.close()
+    this.input = null
+    this.ready = false
+    this.output = new AudioOut({
+      sampleRate: this.outputSampleRate,
+      onWritable: (size) => {
+        const turn = this.turns[0]
+        if (!turn?.ready || turn.ending) return
+        // Drain notification follows the callback that submitted the final
+        // samples; a following turn cannot overwrite a previous stop marker.
+        if (turn.end !== undefined && this.playedBytes >= turn.end) {
+          this.onOutputLevelChanged?.(0)
+          this.finishOutputTurn(turn)
+          return
+        }
+        let start = this.outputBufferTail
+        const stop = this.outputBufferHead
+        let remaining = (stop - start + this.outputBufferSize) % this.outputBufferSize
+        if (turn.end !== undefined) remaining = Math.min(remaining, turn.end - this.playedBytes)
+        remaining = Math.min(remaining, size)
+        let level = 0
+        while (remaining > 0) {
+          const count = Math.min(remaining, this.outputBufferSize - start)
+          const samples = new Uint8Array(this.outputBuffer, start, count)
+          if (this.onOutputLevelChanged) level = Math.max(level, computeLevel(samples))
+          this.output.write(samples)
+          start = (start + count) % this.outputBufferSize
+          remaining -= count
+          this.playedBytes += count
+        }
+        this.outputBufferTail = start
+        Atomics.store(this.barrier, 0, start)
+        Atomics.notify(this.barrier, 0)
+        if (this.level !== level) {
+          this.level = level
+          this.onOutputLevelChanged?.(level)
+        }
+      },
+    })
+    this.output.start()
+    this.output.volume = this.volume
+  }
+}
+
+export default ChatAudioIO

--- a/firmware/host/modules/conversation/chat-audioio/xiaozhi-model.js
+++ b/firmware/host/modules/conversation/chat-audioio/xiaozhi-model.js
@@ -39,6 +39,9 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
     this.sessionID = ''
     this.uploading = false
     this.listeningMode = 'auto'
+    this.turnControl = 'halfDuplex'
+    this.outputTurnId = 0
+    this.outputWrittenBytes = 0
     this.features = {}
     this.helloExtension = {}
     this.functions = []
@@ -57,6 +60,10 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
     this.pcmRing = message.pcmRing
     this.pcmRingState = message.pcmRingState
     try {
+      this.turnControl = message.turnControl ?? 'halfDuplex'
+      if (!['halfDuplex', 'downlink'].includes(this.turnControl)) {
+        throw new Error(this.turnControl === 'fullDuplex' ? 'fullDuplex is not implemented' : 'Invalid turnControl')
+      }
       const configuration = normalizeConfiguration(message)
       const endpoint = parseWebSocketEndpoint(configuration.endpoint)
       const apiKey = String(configuration.authentication?.bearerToken ?? '')
@@ -220,11 +227,14 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
       this.decoder = new OpusDecoder(sampleRate, frameDuration)
       this.decoderPCM = new SharedArrayBuffer(this.decoder.outputBytes)
       this.encoder?.close()
-      this.encoder = new OpusEncoder()
-      if (!this.pcmRing || !this.pcmRingState) throw new Error('XiaoZhi PCM ring is not configured')
-      this.encoder.attachPcmRing(this.pcmRing, this.pcmRingState)
-      this.encoderPacket = new SharedArrayBuffer(this.encoder.outputBytes)
-      this.encoderTimer = Timer.repeat(() => this.flushEncodedAudio(), 20)
+      this.encoder = undefined
+      if (this.turnControl === 'halfDuplex') {
+        this.encoder = new OpusEncoder()
+        if (!this.pcmRing || !this.pcmRingState) throw new Error('XiaoZhi PCM ring is not configured')
+        this.encoder.attachPcmRing(this.pcmRing, this.pcmRingState)
+        this.encoderPacket = new SharedArrayBuffer(this.encoder.outputBytes)
+        this.encoderTimer = Timer.repeat(() => this.flushEncodedAudio(), 20)
+      }
       this.silence = new ArrayBuffer(this.decoder.outputBytes)
       this.outputSampleRate = sampleRate
       this.sessionID = message.session_id ?? ''
@@ -232,7 +242,9 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
       this.pendingMcpCalls = Object.create(null)
       this.resetEncodeStats()
       this.resetDecodeStats()
-      this.uploading = true
+      this.uploading = this.turnControl === 'halfDuplex'
+      this.outputTurnId = 0
+      this.outputWrittenBytes = 0
       this.postMessage({
         id: 'configureAudio',
         inputSampleRate: INPUT_SAMPLE_RATE,
@@ -242,7 +254,7 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
         `[opus] decoder heap internal=${this.decoder.internalHeapBytes ?? 0}B psram=${this.decoder.psramHeapBytes ?? 0}B\n`,
       )
       trace(
-        `[opus] encoder heap internal=${this.encoder.internalHeapBytes ?? 0}B psram=${this.encoder.psramHeapBytes ?? 0}B\n`,
+        `[opus] encoder heap internal=${this.encoder?.internalHeapBytes ?? 0}B psram=${this.encoder?.psramHeapBytes ?? 0}B\n`,
       )
       this.post('connected')
       this.startListening({ mode: this.listeningMode })
@@ -252,6 +264,7 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
   }
 
   startListening(message = {}) {
+    if (this.turnControl === 'downlink') return
     if (!this.encoder) {
       this.postProtocolWarning('cannot start listening before XiaoZhi hello')
       return
@@ -265,12 +278,14 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
   }
 
   stopListening() {
+    if (this.turnControl === 'downlink') return
     this.uploading = false
     this.encoder?.clear()
     this.sendProtocolEvent(this.withSession({ type: 'listen', state: 'stop' }))
   }
 
   detectWakeWord(message = {}) {
+    if (this.turnControl === 'downlink') return
     this.sendProtocolEvent(
       this.withSession({
         type: 'listen',
@@ -347,6 +362,7 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
     try {
       const pcmBytes = this.decoder.decode(packet, this.decoderPCM)
       this.parser.copy(new Uint8Array(this.decoderPCM, 0, pcmBytes))
+      this.outputWrittenBytes += pcmBytes
       this.decodePackets += 1
       this.decodeCompressedBytes += packet.byteLength
       this.decodePCMBytes += pcmBytes
@@ -413,7 +429,7 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
         this.decoderPacket = undefined
         this.resetDecodeStats()
         this.postPresentation({ id: 'receiveOutputText', text: '', more: true })
-        this.post('listen')
+        this.postMessage({ id: 'listen', turnId: ++this.outputTurnId })
         break
       case 'sentence_start':
         if (message.glyph_push) {
@@ -440,9 +456,10 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
           )
         }
         this.parser.copy(this.silence)
+        this.outputWrittenBytes += this.silence.byteLength
         this.parser.done()
         this.postPresentation({ id: 'receiveOutputText', text: '' })
-        this.post('speak')
+        this.postMessage({ id: 'speak', turnId: this.outputTurnId, endByte: this.outputWrittenBytes })
         break
     }
   }
@@ -513,6 +530,7 @@ export default class XiaozhiModel extends ServerChatWebSocketWorker {
     this.pendingMcpCalls[call] = { id: payload.id, name: params.name }
     this.postMessage({
       id: 'receiveFunctionCall',
+      turnId: this.outputTurnId,
       call,
       name: params.name,
       parameters: args,

--- a/firmware/host/modules/conversation/chat.ts
+++ b/firmware/host/modules/conversation/chat.ts
@@ -25,6 +25,7 @@ export type ChatConfig = {
 }
 
 export type ChatListeningMode = 'auto' | 'manual' | 'realtime'
+export type TurnControl = 'fullDuplex' | 'halfDuplex' | 'downlink'
 
 export type XiaozhiV1McpOptions = {
   serverInfo?: {
@@ -73,7 +74,7 @@ export type XiaozhiV1Connection = Readonly<{
  */
 export type ChatConnection = XiaozhiV1Connection
 
-export const XIAOZHI_V1_CONTRACT_VERSION = 1
+export const XIAOZHI_V1_CONTRACT_VERSION = 2
 
 /** Creates a direct connection to a XiaoZhi WebSocket v1 compatible server. */
 export function createXiaozhiV1Connection(options: XiaozhiV1ConnectionOptions): XiaozhiV1Connection {
@@ -128,6 +129,8 @@ export type ChatGlyphPush = {
 }
 
 export type ChatCallbacks = {
+  onOutputTurnStarted?: (turn: ChatOutputTurn) => void | Promise<void>
+  onOutputTurnEnded?: (turn: ChatOutputTurn) => void | Promise<void>
   onStateChanged?: (state: ChatStateValue, error?: string) => void
   onInputLevelChanged?: (level: number) => void
   onOutputLevelChanged?: (level: number) => void
@@ -145,7 +148,11 @@ export type ChatCallbacks = {
   onGlyphPush?: (glyphPush: ChatGlyphPush) => void
 }
 
+/** Local playback identity. This is never a XiaoZhi wire request identifier. */
+export type ChatOutputTurn = { id: number; isCurrent: () => boolean }
+
 type ChatServiceOptions = {
+  turnControl?: TurnControl
   config?: ChatConfig
   connection?: ChatConnection
   tools?: Record<string, ChatTool>
@@ -290,6 +297,12 @@ export class ChatService {
   #sessionState: ChatSessionState
 
   constructor(options: ChatServiceOptions) {
+    const turnControl = options.turnControl ?? 'halfDuplex'
+    if (turnControl === 'fullDuplex') throw new Error('fullDuplex is not implemented')
+    if (turnControl !== 'halfDuplex' && turnControl !== 'downlink') throw new Error('Invalid turnControl')
+    if (turnControl === 'downlink' && options.connection?.kind !== 'xiaozhi-v1') {
+      throw new Error('downlink requires a XiaoZhi connection')
+    }
     if ((options.config ? 1 : 0) + (options.connection ? 1 : 0) !== 1) {
       throw new Error('ChatService requires exactly one of config or connection')
     }
@@ -297,6 +310,8 @@ export class ChatService {
     this.#sessionState = options.sessionState ?? new ChatSessionState()
     const callbacks = options.callbacks ?? {}
     this.#callbacks = {
+      onOutputTurnStarted: callbacks.onOutputTurnStarted ?? noop,
+      onOutputTurnEnded: callbacks.onOutputTurnEnded ?? noop,
       onStateChanged: callbacks.onStateChanged ?? noop,
       onInputLevelChanged: callbacks.onInputLevelChanged ?? noop,
       onOutputLevelChanged: callbacks.onOutputLevelChanged ?? noop,
@@ -332,6 +347,7 @@ export class ChatService {
       })
     const chatAudioIOConstants = ChatAudioIOCtor as unknown as ChatAudioIOStateConstants
     this.#chat = new ChatAudioIOCtor({
+      turnControl,
       specifier: resolved.specifier,
       configuration: resolved.configuration,
       instructions: resolved.instructions,
@@ -340,6 +356,8 @@ export class ChatService {
       modelID: resolved.modelID,
       apiKey: resolved.apiKey,
       functions: functions.length > 0 ? functions : undefined,
+      onOutputTurnStarted: this.#callbacks.onOutputTurnStarted,
+      onOutputTurnEnded: this.#callbacks.onOutputTurnEnded,
       onStateChanged: (state: number) => {
         this.#state = mapState(state, chatAudioIOConstants)
         this.#error = this.#chat.error ?? ''

--- a/firmware/host/modules/conversation/manifest.json
+++ b/firmware/host/modules/conversation/manifest.json
@@ -14,6 +14,7 @@
       "include": ["$(MODULES)/network/services/chatAudioIO/manifest.json"],
       "modules": {
         "~": "./StackChanChatAudioIO",
+        "stackchanXiaozhiAudioIOBase": "./chat-audioio/xiaozhi-audioio-base",
         "StackChanChatAudioIO": "./chat-audioio/worker-stack"
       }
     },
@@ -27,6 +28,7 @@
       ],
       "modules": {
         "~": ["./StackChanChatAudioIO", "./chat-audioio/pcm-ring-writer"],
+        "stackchanXiaozhiAudioIOBase": "./chat-audioio/xiaozhi-audioio-base",
         "StackChanChatAudioIO": "./chat-audioio/worker-stack",
         "stackchanPcmRingWriter": "./chat-audioio/pcm-ring-writer-native"
       },
@@ -51,6 +53,7 @@
       "include": ["$(MODULES)/network/services/chatAudioIO/manifest.json"],
       "modules": {
         "~": "./StackChanChatAudioIO",
+        "stackchanXiaozhiAudioIOBase": "./chat-audioio/xiaozhi-audioio-base",
         "StackChanChatAudioIO": "./chat-audioio/worker-stack"
       }
     },


### PR DESCRIPTION
XiaoZhiの音声出力でWorkerデコーダー、容量を制限したPCMリング、出力の開始・終了処理を共有します。通常会話はhalfDuplexを既定とし、外部出力用のdownlinkではマイク入力・エンコーダーを確保しません。

ローカルのturnControlを排他的に扱い、FIFO再生、キュー経由のMCP呼び出し、中止後の古いコールバックを識別する処理を追加します。fullDuplexは未対応として拒否します。既存SDKプロバイダーとの互換性を保ち、接続方針と認証情報は呼び出し元が管理します。

変更規模はminorです。Changesetを含みます。

### 検証

- 会話関連のXSテスト5 manifestがSDK 9.0 / 9.5で通過。CIの全6機種ビルド、web、アーキテクチャ、Biome、XS、smokeも通過。
- LAN試験は各モード5ターン、各96 Opusパケット。全10ターンで全パケットをデコード。開始からdrainまでの中央値はdownlink 2482 ms、halfDuplex 2001 ms。無音fixtureのため、聴感上の途切れは評価していません。
- 本番Cloudflare APIとCoreS3実機を接続し、ブラウザのOAuth認可から外部出力を実行。同一起動中に音声＋動作20件と動作のみ20件が成功。
- 再生途中の中止ではrender.canceledを受信し、端末の出力接続を閉じ、トルクOFF 28 ms、表示の終了処理88 msで復帰。
- 通常会話への割込みは、端末のtoggleChatSessionを試験用タイマーから実行。マイク入力状態への移行と、停止後のdownlink再接続を確認。downlinkのencoder確保は0 B、通常会話ではencoderの確保を確認。試験用タイマーは撤去済み。
- OAuth連携の解除後、同じBearerで接続できないことを確認。

### 検証の限界

サーボ側 #697 のACK破損が再起動後と割込み・復帰の試験で再発しています。音声・動作を含む全体の安定性、および聴感での品質は未合格です。通常会話による割込みは現行サーバーではrender.failed / device_downlink_closedになります。40件の後には一時的な接続断も発生し、自動再接続を確認しました。

共有音声処理のレビューを進められる状態ですが、統合版の出荷判断には上記の実機問題の切り分けが必要です。関連: meganetaaan/stack-chan-ai #93–#96、独立したサーボ修正 #697。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added XiaoZhi turn-control options, including default half-duplex and downlink modes.
  - Downlink mode supports cloud audio playback without microphone capture or automatic listening.
  - Added output-turn lifecycle callbacks with cancellation-safe turn tracking.
  - Improved audio buffering and playback handling for reliable FIFO turn ordering.
  - Unsupported modes now fail before audio resources are created.

- **Documentation**
  - Added documentation covering turn-control behavior, callbacks, audio flow, and configuration.

- **Tests**
  - Expanded coverage for turn modes, playback boundaries, cancellation, contract compatibility, and resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->