### PR TITLE
fix: disable Wi-Fi modem sleep on M5StackChan CoreS3

### DIFF
--- a/.changeset/cores3-wifi-modem-sleep.md
+++ b/.changeset/cores3-wifi-modem-sleep.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": patch
+---
+
+Disable Wi-Fi modem sleep on M5StackChan CoreS3 to reduce receive delays during streamed audio playback. Wi-Fi stays awake while connected, which can increase battery use.

--- a/firmware/host/modules/connectivity/__tests__/network-manager.test.ts
+++ b/firmware/host/modules/connectivity/__tests__/network-manager.test.ts
@@ -8,6 +8,9 @@ import { getFakeWiFiInstances, resetFakeWiFi } from './fakes/ecma-wifi.js'
 
 function installBareSpecifierPackages(): void {
   const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+  writeAliasPackage(modulesRoot, 'modules', resolve(modulesRoot, 'testing/fakes/modules.js'), {
+    hasDefaultExport: true,
+  })
   writeAliasPackage(modulesRoot, 'network-service', resolve(modulesRoot, 'connectivity/network-service.js'))
   writeAliasPackage(modulesRoot, 'network-state', resolve(modulesRoot, 'connectivity/network-state.js'))
   writeAliasPackage(modulesRoot, 'sntp', resolve(modulesRoot, 'connectivity/__tests__/fakes/sntp.js'), {

--- a/firmware/host/modules/connectivity/__tests__/network-service.test.ts
+++ b/firmware/host/modules/connectivity/__tests__/network-service.test.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
+import { resetModules } from '../../testing/fakes/modules.js'
 import { writeAliasPackage, writeAliasPackageSubpath } from '../../testing/node-alias-package.js'
 import FakeWiFi, { getFakeWiFiInstances, resetFakeWiFi } from './fakes/ecma-wifi.js'
 import NTP, { resetNTP } from './fakes/ntp.js'
@@ -10,6 +11,9 @@ import NTP, { resetNTP } from './fakes/ntp.js'
 /** Map Moddable bare imports to local Node test doubles. */
 function installBareSpecifierPackages(): void {
   const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+  writeAliasPackage(modulesRoot, 'modules', resolve(modulesRoot, 'testing/fakes/modules.js'), {
+    hasDefaultExport: true,
+  })
   writeAliasPackage(modulesRoot, 'network-state', resolve(modulesRoot, 'connectivity/network-state.js'))
   writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), {
     hasDefaultExport: true,
@@ -31,6 +35,7 @@ const ntpDNS = { io: class FakeDNS {} }
 /** Reset platform doubles and install a complete NTP provider for each test. */
 async function setup(configValues: Record<string, unknown> = {}) {
   installBareSpecifierPackages()
+  resetModules()
   resetFakeWiFi()
   resetNTP()
   ;(globalThis as typeof globalThis & { device: unknown }).device = {
@@ -51,6 +56,23 @@ async function setup(configValues: Record<string, unknown> = {}) {
   }
   return { NetworkService: networkService.NetworkService, traces, timer: timer.default, time: time.default }
 }
+
+test('NetworkService applies optional board power policy after initialization and before connecting', async () => {
+  const { NetworkService } = await setup()
+  let calls = 0
+  resetModules({
+    'wifi-power-save': () => {
+      calls += 1
+      assert.equal(getFakeWiFiInstances().length, 1)
+      assert.equal(getFakeWiFiInstances()[0].connectOptions, undefined)
+    },
+  })
+  const service = new NetworkService({ ssid: 'stackchan-ap', password: 'secret' })
+  assert.equal(calls, 1)
+  service.connect()
+  assert.equal(calls, 1)
+  service.close()
+})
 
 test('NetworkService connects through ECMA-419 Wi-Fi and resolves after IP address', async () => {
   const { NetworkService } = await setup()

--- a/firmware/host/modules/connectivity/__tests__/network-service/manifest.json
+++ b/firmware/host/modules/connectivity/__tests__/network-service/manifest.json
@@ -1,5 +1,8 @@
 {
-  "include": ["$(MODDABLE)/examples/io/udp/ntp/manifest_ntp.json"],
+  "include": [
+    "$(MODDABLE)/examples/io/udp/ntp/manifest_ntp.json",
+    "$(MODULES)/base/modules/manifest.json"
+  ],
   "modules": {
     "network-service": "../../network-service",
     "network-state": "../../network-state",

--- a/firmware/host/modules/connectivity/esp32/wifi-power-save.c
+++ b/firmware/host/modules/connectivity/esp32/wifi-power-save.c
@@ -1,0 +1,11 @@
+#include "xsmc.h"
+#include "esp_wifi.h"
+
+void xs_stackchan_disable_wifi_power_save(xsMachine *the)
+{
+    wifi_ps_type_t mode;
+    if (ESP_OK != esp_wifi_set_ps(WIFI_PS_NONE))
+        xsUnknownError("failed to disable Wi-Fi power save");
+    if (ESP_OK != esp_wifi_get_ps(&mode) || mode != WIFI_PS_NONE)
+        xsUnknownError("Wi-Fi power save remains enabled");
+}

--- a/firmware/host/modules/connectivity/esp32/wifi-power-save.js
+++ b/firmware/host/modules/connectivity/esp32/wifi-power-save.js
@@ -1,0 +1,3 @@
+export default function disableWiFiPowerSave() {
+  native('xs_stackchan_disable_wifi_power_save').call(this)
+}

--- a/firmware/host/modules/connectivity/manifest.json
+++ b/firmware/host/modules/connectivity/manifest.json
@@ -96,6 +96,11 @@
       "modules": {
         "~": "./local-peer-capability"
       }
+    },
+    "esp32/m5stackchan_cores3": {
+      "modules": {
+        "wifi-power-save": "./esp32/wifi-power-save"
+      }
     }
   },
   "typescript": {

--- a/firmware/host/modules/connectivity/manifest.json
+++ b/firmware/host/modules/connectivity/manifest.json
@@ -13,7 +13,8 @@
     "./http-server/manifest.json",
     "./mcp-server/manifest.json",
     "./mcp-client/manifest.json",
-    "../../app/manifest_typings.json"
+    "../../app/manifest_typings.json",
+    "$(MODULES)/base/modules/manifest.json"
   ],
   "modules": {
     "*": [

--- a/firmware/host/modules/connectivity/network-service.ts
+++ b/firmware/host/modules/connectivity/network-service.ts
@@ -1,5 +1,6 @@
 import WiFi from 'ecma-wifi'
 import config from 'mc/config'
+import Modules from 'modules'
 import {
   NetworkConnectionState,
   NetworkConnectionStateMachine,
@@ -54,6 +55,8 @@ export class NetworkService {
         this.#handleWiFiChanged(property)
       },
     })
+    // Disable modem sleep after the driver initializes, before connecting.
+    if (Modules.has('wifi-power-save')) (Modules.importNow('wifi-power-save') as () => void)()
   }
 
   get state(): NetworkState {


### PR DESCRIPTION
M5StackChan CoreS3のWi-Fiモデムスリープを無効にし、ストリーミング音声の受信遅延を軽減します。Wi-Fiドライバーの初期化直後、接続開始前に `WIFI_PS_NONE` を設定し、読み戻して反映を確認します。

対象ボードだけにネイティブモジュールを組み込みます。比較用のON/OFF切替、計測ログ、再生方式の変更は含みません。Release impact: **patch**。Wi-Fiが起きた状態を維持するため消費電力が増える可能性があり、changesetにも記載しています。

## ベースと検証

- ベースは `feat/moddable-9.5`（#692、`91ad16cd`）。CI修正で追加した依存宣言がNTP移行と同じmanifestを変更するため、9.5.0対応ブランチを基点にしています。
- develop上の単体テスト405件、#692との統合状態で411件が成功。Wi-Fi初期化後かつ接続前にボード固有の設定を適用する順序を検証。
- SDK 9.5.0／ESP-IDF 6.1で、#692との統合状態のM5StackChan CoreS3リリースビルドを確認。
- 自己レビューで対象ボードの限定、初期化順序、設定失敗時の検出、リリース影響を確認。

## 実機での確認

SDK 9.5.0・XiaoZhi対応を含む比較用構成で、同一LANの60秒Opus音源を各条件3回再生しました。200ms超の受信間隔は省電力ONの10回からOFFの1回へ減少。再生時間の中央値は60.337秒と60.423秒で、再生時間の短縮は確認していません。

改善後の構成について、利用者の聴感では知覚できる途切れが1ターンに0〜1回程度まで減ったことを確認しています。以前の構成からはSDKと接続先も変わっているため、この聴感上の改善すべてを省電力OFF単独の効果とは判断していません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reduced streamed-audio receive delays on M5StackChan CoreS3 devices by disabling Wi‑Fi modem sleep during connected operation.
  * Added HTTP keep-alive support, request-size limits, and improved routing for hosted services.
  * Added XS archive compatibility checks before MOD installation.

* **Bug Fixes**
  * Improved network time synchronization cleanup and connection handling.

* **Documentation**
  * Added Moddable SDK 9.5.0 migration guidance and documented increased battery usage during connected operation.
  * Updated installation guidance for firmware and archive compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## CI修正

NodeのNetworkManagerテストにも `modules` のテスト用設定を追加し、他テストの実行順に依存しないようにしました。NetworkServiceと独立スモークテストのmanifestにもSDKのmodule loader依存を明示しました。NetworkManagerの単独実行、全411件の単体テスト、失敗していたModdableスモークテストの成功をローカルで確認しています。
