### PR TITLE
Add deterministic synchronization for gallery sample sources

### DIFF
--- a/web/mod-gallery/README.md
+++ b/web/mod-gallery/README.md
@@ -1,0 +1,31 @@
+# Gallery source synchronization
+
+Firmware examples are the source of truth for the files declared in
+`sample-sources.json`. From the repository root, run:
+
+```sh
+npm --prefix web run sync:gallery
+npm --prefix web run check:gallery
+```
+
+The first command copies changed or missing files byte-for-byte. The second
+reports stale copies without writing and exits unsuccessfully when synchronization
+is needed. Both commands resolve paths relative to the script, independently of
+the working directory. The existing web test suite also checks the copies, so CI
+detects forgotten synchronization without silently fixing the working tree.
+
+Update the firmware example, run synchronization, and include the changed gallery
+copies in the same pull request. Add new shared sources, images, README files or
+third-party license files to the corresponding mapping. Review removed files
+explicitly: the command only owns mapped files and never deletes other content.
+
+This is an incremental step toward issue #689. Generated copies remain tracked
+and keep their existing package-relative URLs. Gallery definitions, gallery-only
+instructions and prebuilt XSA archives remain separately maintained. Synchronizing
+JavaScript or TypeScript does **not** rebuild an XSA or establish that it matches
+the new source; follow the existing firmware build and device validation workflow
+when updating executable artifacts. A build-only gallery and XSA generation policy
+are separate follow-up decisions.
+
+Release impact: none. This changes contributor tooling and drift checks, without
+changing the distributed sample bytes or runtime behavior.

--- a/web/mod-gallery/mod-definition.test.mjs
+++ b/web/mod-gallery/mod-definition.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 
 import { isXsArchive, xsArchiveVersion } from '../editor/mod-builder.mjs'
@@ -12,6 +14,27 @@ import { syncSamples } from './sync-samples.mjs'
 
 test('Gallery source copies match the firmware examples', () => {
   assert.deepEqual(syncSamples({ check: true }), [])
+})
+
+test('Source mappings cover every catalog text package and every packaged source file', () => {
+  const catalog = JSON.parse(readFileSync(catalogUrl, 'utf8'))
+  const mappings = JSON.parse(readFileSync(new URL('./sample-sources.json', import.meta.url), 'utf8'))
+  const targets = catalog.definitions
+    .filter((path) => path.startsWith('samples/'))
+    .flatMap((path) => {
+      const definition = JSON.parse(readFileSync(new URL(path, catalogUrl), 'utf8'))
+      if (definition.type !== 'text') return []
+      const packagePath = path.slice('samples/'.length, path.lastIndexOf('/') + 1)
+      return [packagePath + definition.source.path.slice(0, definition.source.path.lastIndexOf('/'))]
+    })
+  assert.deepEqual(mappings.map(({ target }) => target).sort(), targets.sort())
+  for (const { target, files } of mappings) {
+    const directory = new URL(`./samples/${target}/`, import.meta.url)
+    const packagedFiles = readdirSync(directory, { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => relative(fileURLToPath(directory), join(entry.parentPath, entry.name)).split(sep).join('/'))
+    assert.deepEqual([...files].sort(), packagedFiles.sort(), `${target}: all packaged sources must stay mapped`)
+  }
 })
 
 const catalogUrl = new URL('./catalog.json', import.meta.url)

--- a/web/mod-gallery/mod-definition.test.mjs
+++ b/web/mod-gallery/mod-definition.test.mjs
@@ -8,6 +8,12 @@ import { parseVisualProject } from '../editor/project-format.mjs'
 import { analyzeWorkspace } from '../editor/project-validator.mjs'
 import { loadModCatalog, parseModDefinition, validatePackagePath } from './mod-definition.mjs'
 
+import { syncSamples } from './sync-samples.mjs'
+
+test('Gallery source copies match the firmware examples', () => {
+  assert.deepEqual(syncSamples({ check: true }), [])
+})
+
 const catalogUrl = new URL('./catalog.json', import.meta.url)
 
 async function fileFetch(url) {
@@ -62,81 +68,6 @@ test('テキストMODの成果物は既存の実行互換性を維持する', as
       archive.includes(Buffer.from('/home/')),
       false,
       `${definition.id}: artifact should not expose build paths`
-    )
-  }
-})
-
-test('MediaPipe GalleryパッケージはFirmwareサンプルと同じ実行ソースを公開する', () => {
-  const firmware = new URL('../../firmware/mods/examples/mediapipe_ble/', import.meta.url)
-  const gallery = new URL('./samples/mediapipe-ble/mod/', import.meta.url)
-  for (const filename of ['manifest.json', 'mod.js', 'tracking-message.js', 'tracking-receiver.js']) {
-    assert.equal(
-      readFileSync(new URL(filename, gallery), 'utf8'),
-      readFileSync(new URL(filename, firmware), 'utf8'),
-      `${filename} should not drift between the firmware example and gallery package`
-    )
-  }
-})
-
-test('MCP GalleryパッケージはFirmwareサンプルと同じ実行ソースを公開する', () => {
-  const firmware = new URL('../../firmware/mods/examples/mcp/', import.meta.url)
-  const gallery = new URL('./samples/mcp/mod/', import.meta.url)
-  for (const filename of ['manifest.json', 'mod.js']) {
-    assert.equal(
-      readFileSync(new URL(filename, gallery), 'utf8'),
-      readFileSync(new URL(filename, firmware), 'utf8'),
-      `${filename} should not drift between the firmware example and gallery package`
-    )
-  }
-})
-
-test('Codex Voice GalleryパッケージはFirmwareサンプルと同じ実行ソースを公開する', () => {
-  const firmware = new URL('../../firmware/mods/examples/codex_voice/', import.meta.url)
-  const gallery = new URL('./samples/codex-voice/mod/', import.meta.url)
-  for (const filename of ['manifest.json', 'mod.js']) {
-    assert.equal(
-      readFileSync(new URL(filename, gallery), 'utf8'),
-      readFileSync(new URL(filename, firmware), 'utf8'),
-      `${filename} should not drift between the firmware example and gallery package`
-    )
-  }
-})
-
-test('Stack-chanミニゲーム集GalleryパッケージはFirmwareサンプルと同じ実行ソースを公開する', () => {
-  const firmware = new URL('../../firmware/mods/examples/stackchan_minigames/', import.meta.url)
-  const gallery = new URL('./samples/stackchan-minigames/miniapp/', import.meta.url)
-  for (const filename of [
-    'manifest.json',
-    'miniapp.ts',
-    'README.md',
-    'README_ja.md',
-    'LICENSE.mouse-follower',
-    'assets/stack-chan.png',
-    'assets/player-left.png',
-    'assets/player-center.png',
-    'assets/player-right.png',
-    'assets/screw.png',
-    'assets/m5stack.png',
-    'assets/bubble.png',
-    'assets/bomb.png',
-    'assets/miss.png',
-  ]) {
-    assert.deepEqual(
-      readFileSync(new URL(filename, gallery)),
-      readFileSync(new URL(filename, firmware)),
-      `${filename} should not drift between the firmware example and gallery package`
-    )
-  }
-})
-
-test('UI Playground GalleryパッケージはFirmwareサンプルと同じ実行ソースを公開する', () => {
-  const firmware = new URL('../../firmware/mods/examples/mini_app_ui_sample/', import.meta.url)
-  const gallery = new URL('./samples/ui-playground/miniapp/', import.meta.url)
-  for (const filename of ['manifest.json', 'miniapp.ts']) {
-    assert.equal(
-      readFileSync(new URL(filename, gallery), 'utf8'),
-      readFileSync(new URL(filename, firmware), 'utf8'),
-      `${filename} should not drift between the firmware example and gallery package`
     )
   }
 })

--- a/web/mod-gallery/sample-sources.json
+++ b/web/mod-gallery/sample-sources.json
@@ -1,0 +1,42 @@
+[
+  {
+    "source": "mediapipe_ble",
+    "target": "mediapipe-ble/mod",
+    "files": ["manifest.json", "mod.js", "tracking-message.js", "tracking-receiver.js"]
+  },
+  {
+    "source": "mcp",
+    "target": "mcp/mod",
+    "files": ["manifest.json", "mod.js"]
+  },
+  {
+    "source": "codex_voice",
+    "target": "codex-voice/mod",
+    "files": ["manifest.json", "mod.js"]
+  },
+  {
+    "source": "stackchan_minigames",
+    "target": "stackchan-minigames/miniapp",
+    "files": [
+      "manifest.json",
+      "miniapp.ts",
+      "README.md",
+      "README_ja.md",
+      "LICENSE.mouse-follower",
+      "assets/stack-chan.png",
+      "assets/player-left.png",
+      "assets/player-center.png",
+      "assets/player-right.png",
+      "assets/screw.png",
+      "assets/m5stack.png",
+      "assets/bubble.png",
+      "assets/bomb.png",
+      "assets/miss.png"
+    ]
+  },
+  {
+    "source": "mini_app_ui_sample",
+    "target": "ui-playground/miniapp",
+    "files": ["manifest.json", "miniapp.ts"]
+  }
+]

--- a/web/mod-gallery/sync-samples.mjs
+++ b/web/mod-gallery/sync-samples.mjs
@@ -1,0 +1,78 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const galleryRoot = fileURLToPath(new URL('./samples/', import.meta.url))
+const firmwareRoot = fileURLToPath(new URL('../../firmware/mods/examples/', import.meta.url))
+const sources = JSON.parse(readFileSync(new URL('./sample-sources.json', import.meta.url), 'utf8'))
+
+function packagePath(root, path) {
+  if (
+    typeof path !== 'string' ||
+    path.includes('\\') ||
+    path.split('/').some((part) => !part || part === '.' || part === '..')
+  ) {
+    throw new Error(`Invalid sample path: ${path}`)
+  }
+  return resolve(root, path)
+}
+
+// Read every source before writing anything: a missing input must not leave a
+// partially synchronized gallery. Only explicitly mapped files are owned here.
+export function syncSamples({
+  check = false,
+  inputRoot = firmwareRoot,
+  outputRoot = galleryRoot,
+  mappings = sources,
+} = {}) {
+  const targets = new Set()
+  const copies = mappings.flatMap(({ source, target, files }) =>
+    files.map((file) => {
+      const destination = packagePath(outputRoot, `${target}/${file}`)
+      if (targets.has(destination)) throw new Error(`Duplicate sample destination: ${destination}`)
+      targets.add(destination)
+      return {
+        destination,
+        name: `${target}/${file}`,
+        bytes: readFileSync(packagePath(inputRoot, `${source}/${file}`)),
+      }
+    })
+  )
+  const changed = []
+  for (const { destination, name, bytes } of copies) {
+    let current
+    try {
+      current = readFileSync(destination)
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error
+    }
+    if (current?.equals(bytes)) continue
+    changed.push(name)
+    if (!check) {
+      mkdirSync(dirname(destination), { recursive: true })
+      writeFileSync(destination, bytes)
+    }
+  }
+  return changed
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const args = process.argv.slice(2)
+    if (args.some((arg) => arg !== '--check')) throw new Error('Usage: node sync-samples.mjs [--check]')
+    const check = args.includes('--check')
+    const changed = syncSamples({ check })
+    if (changed.length) {
+      console.log(`${check ? 'Outdated' : 'Updated'} gallery source files:\n${changed.join('\n')}`)
+      if (check) {
+        console.error('Run npm --prefix web run sync:gallery and include the updated files.')
+        process.exitCode = 1
+      }
+    } else {
+      console.log('Gallery source files are up to date.')
+    }
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}

--- a/web/mod-gallery/sync-samples.test.mjs
+++ b/web/mod-gallery/sync-samples.test.mjs
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 import { syncSamples } from './sync-samples.mjs'
 
@@ -66,13 +65,28 @@ test('ambiguous or escaping mappings are rejected', (t) => {
   assert.equal(readFileSync(join(options.outputRoot, 'sample/mod/mod.js'), 'utf8'), 'old source')
 })
 
-test('CLI check can run outside the repository and rejects unknown flags', (t) => {
-  const root = mkdtempSync(join(tmpdir(), 'stackchan-gallery-cli-'))
+test('CLI runs outside its package and reports drift, synchronization and invalid flags', (t) => {
+  const options = fixture(t)
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'stackchan-gallery-cli-')))
   t.after(() => rmSync(root, { recursive: true, force: true }))
-  const script = new URL('./sync-samples.mjs', import.meta.url)
-  const check = spawnSync(process.execPath, [fileURLToPath(script), '--check'], { cwd: root, encoding: 'utf8' })
+  const gallery = join(root, 'web/mod-gallery')
+  mkdirSync(gallery, { recursive: true })
+  cpSync(options.inputRoot, join(root, 'firmware/mods/examples'), { recursive: true })
+  cpSync(options.outputRoot, join(gallery, 'samples'), { recursive: true })
+  const script = join(gallery, 'sync-samples.mjs')
+  cpSync(new URL('./sync-samples.mjs', import.meta.url), script)
+  writeFileSync(join(gallery, 'sample-sources.json'), JSON.stringify(options.mappings))
+  const run = (...args) => spawnSync(process.execPath, [script, ...args], { cwd: tmpdir(), encoding: 'utf8' })
+  const stale = run('--check')
+  assert.equal(stale.status, 1, stale.stderr + stale.stdout)
+  assert.match(stale.stdout, /Outdated gallery source files/)
+  assert.equal(readFileSync(join(gallery, 'samples/sample/mod/mod.js'), 'utf8'), 'old source')
+  const sync = run()
+  assert.equal(sync.status, 0, sync.stderr + sync.stdout)
+  const check = run('--check')
   assert.equal(check.status, 0, check.stderr + check.stdout)
-  const invalid = spawnSync(process.execPath, [fileURLToPath(script), '--invalid'], { cwd: root, encoding: 'utf8' })
+  assert.match(check.stdout, /up to date/)
+  const invalid = run('--invalid')
   assert.equal(invalid.status, 1)
   assert.match(invalid.stderr, /Usage:/)
 })

--- a/web/mod-gallery/sync-samples.test.mjs
+++ b/web/mod-gallery/sync-samples.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+import { syncSamples } from './sync-samples.mjs'
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'stackchan-gallery-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const inputRoot = join(root, 'firmware')
+  const outputRoot = join(root, 'gallery')
+  mkdirSync(join(inputRoot, 'example/assets'), { recursive: true })
+  mkdirSync(join(outputRoot, 'sample/mod'), { recursive: true })
+  writeFileSync(join(inputRoot, 'example/mod.js'), 'export default {}\n')
+  writeFileSync(join(inputRoot, 'example/assets/image.png'), Buffer.from([0, 255, 128, 10]))
+  writeFileSync(join(inputRoot, 'example/LICENSE'), 'Upstream attribution\n')
+  writeFileSync(join(outputRoot, 'sample/mod/mod.js'), 'old source')
+  writeFileSync(join(outputRoot, 'sample/archive.xsa'), 'keep archive')
+  writeFileSync(join(outputRoot, 'sample/README.md'), 'gallery-specific instructions')
+  return {
+    inputRoot,
+    outputRoot,
+    mappings: [{ source: 'example', target: 'sample/mod', files: ['mod.js', 'assets/image.png', 'LICENSE'] }],
+  }
+}
+
+test('check is read-only; sync preserves binary assets and attribution and is repeatable', (t) => {
+  const options = fixture(t)
+  const changed = ['sample/mod/mod.js', 'sample/mod/assets/image.png', 'sample/mod/LICENSE']
+  assert.deepEqual(syncSamples({ ...options, check: true }), changed)
+  assert.equal(readFileSync(join(options.outputRoot, 'sample/mod/mod.js'), 'utf8'), 'old source')
+  assert.throws(() => readFileSync(join(options.outputRoot, 'sample/mod/LICENSE')), { code: 'ENOENT' })
+  assert.deepEqual(syncSamples(options), changed)
+  for (const file of options.mappings[0].files) {
+    assert.deepEqual(
+      readFileSync(join(options.inputRoot, 'example', file)),
+      readFileSync(join(options.outputRoot, 'sample/mod', file))
+    )
+  }
+  assert.deepEqual(syncSamples(options), [])
+  assert.deepEqual(syncSamples({ ...options, check: true }), [])
+  assert.equal(readFileSync(join(options.outputRoot, 'sample/archive.xsa'), 'utf8'), 'keep archive')
+  assert.equal(readFileSync(join(options.outputRoot, 'sample/README.md'), 'utf8'), 'gallery-specific instructions')
+  writeFileSync(join(options.inputRoot, 'example/mod.js'), 'updated source')
+  assert.deepEqual(syncSamples({ ...options, check: true }), ['sample/mod/mod.js'])
+  assert.deepEqual(syncSamples(options), ['sample/mod/mod.js'])
+  assert.equal(readFileSync(join(options.outputRoot, 'sample/mod/mod.js'), 'utf8'), 'updated source')
+})
+
+test('missing sources fail before any destination changes', (t) => {
+  const options = fixture(t)
+  options.mappings[0].files.push('missing.js')
+  assert.throws(() => syncSamples(options), { code: 'ENOENT' })
+  assert.equal(readFileSync(join(options.outputRoot, 'sample/mod/mod.js'), 'utf8'), 'old source')
+})
+
+test('ambiguous or escaping mappings are rejected', (t) => {
+  const options = fixture(t)
+  assert.throws(() => syncSamples({ ...options, mappings: [...options.mappings, ...options.mappings] }), /Duplicate/)
+  for (const target of ['../outside', '/absolute', 'sample/../outside', 'sample\\outside']) {
+    assert.throws(() => syncSamples({ ...options, mappings: [{ ...options.mappings[0], target }] }), /Invalid/)
+  }
+  assert.equal(readFileSync(join(options.outputRoot, 'sample/mod/mod.js'), 'utf8'), 'old source')
+})
+
+test('CLI check can run outside the repository and rejects unknown flags', (t) => {
+  const root = mkdtempSync(join(tmpdir(), 'stackchan-gallery-cli-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const script = new URL('./sync-samples.mjs', import.meta.url)
+  const check = spawnSync(process.execPath, [fileURLToPath(script), '--check'], { cwd: root, encoding: 'utf8' })
+  assert.equal(check.status, 0, check.stderr + check.stdout)
+  const invalid = spawnSync(process.execPath, [fileURLToPath(script), '--invalid'], { cwd: root, encoding: 'utf8' })
+  assert.equal(invalid.status, 1)
+  assert.match(invalid.stderr, /Usage:/)
+})

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,8 @@
   "description": "Stack-chan browser tools",
   "scripts": {
     "dev": "vite",
+    "sync:gallery": "node mod-gallery/sync-samples.mjs",
+    "check:gallery": "node mod-gallery/sync-samples.mjs --check",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

- Replace manual copying of five firmware examples into the MOD Gallery with one explicit source mapping and synchronization command.
- This is an incremental step toward #689: existing copies remain tracked, and XSA rebuilding and build-only generation remain follow-up decisions.

## What Changed

- Add `npm --prefix web run sync:gallery` to copy the mapped source, image, README and license files byte-for-byte.
- Add a read-only `check:gallery` command and use the same mapping in the existing web test suite, so CI detects stale copies.
- Validate inputs before writing; preserve unmapped gallery content and existing XSA files.
- Release impact: `none`. Existing distributed files and package-relative URLs are unchanged, so no release note is proposed.

## Verification

- [ ] `cd firmware && npm run format`
- [ ] `cd firmware && npm run lint`
- [ ] `cd firmware && npm run test`
- [ ] `cd firmware && npm run check:legacy-names`
- [x] Other checks were run when relevant

From `web/`: `npm test` passes (206 Node tests and 51 React tests), and `npm run build` passes, with a large-chunk warning. Prettier checks pass for the changed files. All 24 mapped files in the built gallery match the firmware sources byte-for-byte. Synchronization produces no changes on the current tree and repeated runs are covered by tests.

Firmware builds, physical device flashing and interactive simulator operation were not tested. Source synchronization does not rebuild or validate a corresponding XSA; artifact updates still require the existing build and device validation workflow.

## Affected Areas

- [ ] firmware
- [x] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

- Part of #689; intentionally does not close the full build-time generation proposal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to synchronize gallery samples with their firmware examples.
  * Added a check-only command to detect outdated gallery files without modifying them.
  * Synchronization supports mapped files, binary assets, incremental updates, and preserves unrelated content.

* **Documentation**
  * Added contributor guidance for synchronization workflows, CI checks, and scope.

* **Tests**
  * Added coverage for synchronization, validation, read-only checks, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->