### PR TITLE
fix(web): keep Blockly toolbox labels readable in dark mode

### DIFF
--- a/.changeset/readable-blockly-toolbox.md
+++ b/.changeset/readable-blockly-toolbox.md
@@ -1,0 +1,5 @@
+---
+"stackchan-web": patch
+---
+
+Keep Block Editor toolbox category labels readable in dark mode.

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -188,6 +188,14 @@
   }
 
   /*
+   * Blockly keeps its toolbox category rows light in both application themes.
+   * Do not let labels inherit the app's light foreground when dark mode is on.
+   */
+  html.dark .blocklyTreeLabel {
+    color: #000;
+  }
+
+  /*
    * Blockly hides flyout scrollbars with an SVG presentation attribute.
    * Restore that state after Tailwind Preflight's `svg { display: block }`.
    */


### PR DESCRIPTION
## Problem

In dark mode, Blockly toolbox category labels can inherit the application's light foreground color even though Blockly keeps the category rows light. This makes the labels difficult to read.

Closes #612.

## Change

- keep `.blocklyTreeLabel` text black when the application is in dark mode
- scope the override to `html.dark` so light-mode behavior is unchanged

Affected subsystem: `web` / Block Editor styling only.

## Verification

Please verify with:

```bash
cd web
npm run build
npm test
```

Manual check: open the Block Editor, switch to dark mode, and confirm toolbox category labels remain readable while the rest of the application stays in the dark theme.

## Release impact

**patch** — user-visible readability fix for the released Web Block Editor.

Release note text: **Fix Block Editor toolbox category label contrast in dark mode.**

No firmware or hardware behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Blockly toolbox category labels appearing with low contrast or incorrect colors in dark mode.
  - Category labels now consistently render in black for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->